### PR TITLE
Update science run 0 S2 AFT cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -91,13 +91,19 @@ class FiducialCylinder1T(ManyLichen):
 
 
 class S2AreaFractionTop(RangeLichen):
-    """Blah
+    """Cuts events with an unusual fraction of S2 on top array.
 
-    Don't use above XXXX PE due to saturation.
+    ! This is a temporary 'by-eye' cut !
+
+    Primarily cuts gas events with a particularly large S2 AFT, also targets some
+    strange / junk / other events with a low AFT.
+
+    Author: Adam Brown abrown@physik.uzh.ch
+
     """
-    version = 0
+    version = 1
 
-    allowed_range = (0.6, 0.72)
+    allowed_range = (0.5, 0.72)
     variable = 's2_area_fraction_top'
 
 


### PR DESCRIPTION
Replace S2 AFT cut for sciencerun0 with a temporary, but better, cut which does not remove part of the 'good' band