### PR TITLE
Added DAQ veto cut to sciencerun0

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -18,6 +18,7 @@ class AllCuts(ManyLichen):
             InteractionPeaksBiggest(),
             S2AreaFractionTop(),
             S2SingleScatter(),
+            DAQVetoCut(),
         ]
 
 
@@ -124,7 +125,30 @@ class InteractionPeaksBiggest(ManyLichen):
             df.loc[:, self.__class__.__name__] = df.s2 > df.largest_other_s2
             return df
 
+class DAQVetoCut(ManyLichen):
+    """
+    Make sure no DAQ vetos happen during your event. This
+    automatically checks both busy and high-energy vetos. 
+    Requires Proximity minitrees!
+    """
+    version = 0
 
+    def __init__(self):
+        self.lichen_list = [self.BusyCheck(),
+                            self.HEVCheck()]
+
+    class BusyCheck(Lichen):
+        def _process(self, df):
+            df.loc[:, self.__class__.__name__] =df[(abs(df['nearest_busy'])>
+                                                    df['event_duration']/2)]
+            return df
+
+    class HEVCheck(Lichen):
+        def _process(self, df):
+            df.loc[:, self.__class__.__name__ = df[(abs(df['nearest_hev'])>
+                                                    df['event_duration']/2)]
+            return df
+                   
 class SignalOverPreS2Junk(RangeLichen):
     """Cut events with lot of peak area before main S2
     

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -126,10 +126,16 @@ class InteractionPeaksBiggest(ManyLichen):
             return df
 
 class DAQVetoCut(ManyLichen):
-    """
+    """Check if DAQ busy or HE veto
+    
     Make sure no DAQ vetos happen during your event. This
     automatically checks both busy and high-energy vetos. 
-    Requires Proximity minitrees!
+    
+    Requires Proximity minitrees.
+    
+    https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:analysis:firstresults:daqandnoise
+    
+    Author: Daniel Coderre <daniel.coderre@lhep.unibe.ch>
     """
     version = 0
 
@@ -139,14 +145,12 @@ class DAQVetoCut(ManyLichen):
 
     class BusyCheck(Lichen):
         def _process(self, df):
-            df.loc[:, self.__class__.__name__] = abs(df['nearest_busy'])>
-                                                    df['event_duration']/2
+            df.loc[:, self.__class__.__name__] = abs(df['nearest_busy'])> df['event_duration']/2
             return df
 
     class HEVCheck(Lichen):
         def _process(self, df):
-            df.loc[:, self.__class__.__name__] = abs(df['nearest_hev'])>
-                                                    df['event_duration']/2
+            df.loc[:, self.__class__.__name__] = abs(df['nearest_hev']) > df['event_duration']/2
             return df
                    
 class SignalOverPreS2Junk(RangeLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -139,14 +139,14 @@ class DAQVetoCut(ManyLichen):
 
     class BusyCheck(Lichen):
         def _process(self, df):
-            df.loc[:, self.__class__.__name__] =df[(abs(df['nearest_busy'])>
-                                                    df['event_duration']/2)]
+            df.loc[:, self.__class__.__name__] = abs(df['nearest_busy'])>
+                                                    df['event_duration']/2
             return df
 
     class HEVCheck(Lichen):
         def _process(self, df):
-            df.loc[:, self.__class__.__name__ = df[(abs(df['nearest_hev'])>
-                                                    df['event_duration']/2)]
+            df.loc[:, self.__class__.__name__] = abs(df['nearest_hev'])>
+                                                    df['event_duration']/2
             return df
                    
 class SignalOverPreS2Junk(RangeLichen):


### PR DESCRIPTION
This adds a new cut to the sciencerun0.py. The new cut removes all events containing either a busy or high energy veto. 

This introduces a new dependency minitree: the proximity trees. I guess if you try to run without these trees it will throw something like 'field not found'.