### PR TITLE
Add S1MaxPMT Cut

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 History
 =======
 
+* Max PMT in S1 (v0) LowEnergyCuts (#15)
+
+
 0.4.0 (2017-02-24)
 ------------------
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -68,7 +68,7 @@ class S1MaxPMT(Lichen):
     Author: Julien Wulf jwulf@physik.uzh.ch
     """
     def pre(self, df):
-        df.loc[:,'temp'] = 0.050 * df['s1'] + 6
+        df.loc[:,'temp'] = 0.040 * df['s1'] + 5.48
 
     def _process(self, df):
         df.loc[:, self.__class__.__name__] = df['largest_hit_channel'] < df.temp

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -57,11 +57,14 @@ class S1LowEnergyRange(RangeLichen):
     variable = 'cs1'
 
 class S1MaxPMT(Lichen):
-    """ S1Max PMT Cut.
+    """ Cut events which have a high fraction of the area in a single PMT
     
     Cuts events which are mostly seen by one PMT.
     These events could be for example afterpulses or light emission. 
     This is the first version of a "loose" cut based on pax 6.4.2 AmBe and Rn220 
+    
+    https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:yuehuan:analysis:0sciencerun_s1_pmtmax
+    
     Author: Julien Wulf jwulf@physik.uzh.ch
     """
     def pre(self, df):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -61,14 +61,14 @@ class S1MaxPMT(Lichen):
     
     Cuts events which are mostly seen by one PMT.
     These events could be for example afterpulses or light emission. 
-    This is the first version of a "loose" cut based on pax 6.4.2 AmBe and Rn220 
+    This is the 99% Quantil fit using pax 6.4.2 on Rn220 
     
     https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:yuehuan:analysis:0sciencerun_s1_pmtmax
     
     Author: Julien Wulf jwulf@physik.uzh.ch
     """
     def pre(self, df):
-        df.loc[:,'temp'] = 0.040 * df['s1'] + 5.48
+        df.loc[:,'temp'] = 0.052 * df['s1'] + 4.15
 
     def _process(self, df):
         df.loc[:, self.__class__.__name__] = df['largest_hit_channel'] < df.temp

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -27,6 +27,7 @@ class LowEnergyCuts(AllCuts):
         AllCuts.__init__(self)
         self.lichen_list[1] = S1LowEnergyRange()
         self.lichen_list.append(S2Width())
+        self.lichen_list.append(S1MaxPMT())
 
 
 class InteractionExists(RangeLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -68,7 +68,7 @@ class S1MaxPMT(Lichen):
         df.loc[:,'temp'] = 0.050 * df['s1'] + 6
 
     def _process(self, df):
-        df.loc[:, self.__class__.__name__] = df['largest_hit_channel'] > df.temp
+        df.loc[:, self.__class__.__name__] = df['largest_hit_channel'] < df.temp
         return df
     
 class FiducialCylinder1T(ManyLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -57,15 +57,15 @@ class S1LowEnergyRange(RangeLichen):
     variable = 'cs1'
 
 class S1MaxPMT(Lichen):
-    """ Cut events which have a high fraction of the area in a single PMT
+    """Cut events which have a high fraction of the area in a single PMT
     
     Cuts events which are mostly seen by one PMT.
     These events could be for example afterpulses or light emission. 
-    This is the 99% Quantil fit using pax 6.4.2 on Rn220 
+    This is the 99% quantile fit using pax 6.4.2 on Rn220 
     
     https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:yuehuan:analysis:0sciencerun_s1_pmtmax
     
-    Author: Julien Wulf jwulf@physik.uzh.ch
+    Author: Julien Wulf <jwulf@physik.uzh.ch>
     """
     def pre(self, df):
         df.loc[:,'temp'] = 0.052 * df['s1'] + 4.15

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -56,7 +56,21 @@ class S1LowEnergyRange(RangeLichen):
     allowed_range = (0, 200)
     variable = 'cs1'
 
+class S1MaxPMT(Lichen):
+    """ S1Max PMT Cut.
+    
+    Cuts events which are mostly seen by one PMT.
+    These events could be for example afterpulses or light emission. 
+    This is the first version of a "loose" cut based on pax 6.4.2 AmBe and Rn220 
+    Author: Julien Wulf jwulf@physik.uzh.ch
+    """
+    def pre(self, df):
+        df.loc[:,'temp'] = 0.050 * df['s1'] + 6
 
+    def _process(self, df):
+        df.loc[:, self.__class__.__name__] = df['largest_hit_channel'] > df.temp
+        return df
+    
 class FiducialCylinder1T(ManyLichen):
     """Fiducial volume cut.
 


### PR DESCRIPTION
    Cuts events which are mostly seen by one PMT.
    These events could be for example afterpulses or light emission. 
    This is the first version of a "loose" cut based on pax 6.4.2 AmBe and Rn220