### PR TITLE
S2 width cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -214,8 +214,8 @@ class S2Width(ManyLichen):
         diffusion_constant = PAX_CONFIG['WaveformSimulator']['diffusion_constant_liquid']
         v_drift = PAX_CONFIG['DEFAULT']['drift_velocity_liquid']
 
-        w0 = 350 * units.ns
-        return np.sqrt(w0 ** 2 - 3.9656 * diffusion_constant * z / v_drift ** 3)
+        w0 = 348.6 * units.ns
+        return np.sqrt(w0 ** 2 - 4.0325 * diffusion_constant * z / v_drift ** 3)
 
     def subpre(self, df):
         # relative_s2_width

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -190,6 +190,9 @@ class S2SingleScatter(Lichen):
 
 class S2Width(ManyLichen):
     """S2 Width cut based on diffusion model (arXiv::1102.2865).
+    The S2 width cut compares the S2 width to what we could expect based on its depth in the detector. 
+    The inputs to this are the drift velocity and the diffusion constant. 
+    The allowed variation in S2 width is greater at low energy (since it is fluctuating statistically)
  
     It should be applicable to data regardless of if it ER or NR; 
     above cS2 = 1e5 pe ERs the acceptance will go down due to track length effects.

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -205,6 +205,13 @@ class S2Width(ManyLichen):
     above cS2 = 1e5 pe ERs the acceptance will go down due to track length effects.
 
     Author: Jelle, translation to lax by Chris.
+    -------------------------------------------
+    Tune the diffusion model parameters according to note:
+    https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:yuehuan:analysis:0sciencerun_s2width_update0#comparison_with_diffusion_model_cut_by_jelle_pax_v642
+    1) w0: 304 -> 350
+    2) 3.6395 -> 3.9656
+    1) and 2) changing according to Fig7 and Fig8 in the note.
+    Auther: Yuehuan, 2017-02-27
     """
     version = 1
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -189,11 +189,12 @@ class S2SingleScatter(Lichen):
 
 
 class S2Width(ManyLichen):
-    """S2 Width cut based on diffusion model (arXiv::1102.2865).
-    The S2 width cut compares the S2 width to what we could expect based on its depth in the detector. 
-    The inputs to this are the drift velocity and the diffusion constant. 
-    The allowed variation in S2 width is greater at low energy (since it is fluctuating statistically)
- 
+    """S2 Width cut based on diffusion model
+
+    The S2 width cut compares the S2 width to what we could expect based on its depth in the detector. The inputs to
+    this are the drift velocity and the diffusion constant. The allowed variation in S2 width is greater at low 
+    energy (since it is fluctuating statistically) Ref: (arXiv:1102.2865)
+    
     It should be applicable to data regardless of if it ER or NR; 
     above cS2 = 1e5 pe ERs the acceptance will go down due to track length effects.
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -189,29 +189,17 @@ class S2SingleScatter(Lichen):
 
 
 class S2Width(ManyLichen):
-    """S2 Width cut based on diffusion model.
-
-    The S2 width cut compares the S2 width to what we could expect based on its
-    depth in the detector. The inputs to this are the drift velocity and the
-    diffusion constant. The allowed variation in S2 width is greater at low energy
-    (since it is fluctuating statistically).
-
-    The cut is roughly based on the observed distribution in AmBe and Rn data (paxv6.2.0)
-    It is not described in any note, but you can see what it is doing in Sander's note here:
-       https://xecluster.lngs.infn.it/dokuwiki/lib/exe/fetch.php?media=
-       xenon:xenon1t:analysis:subgroup:backgrounds:meetings:170112_pb214_concentration_spectrum.html
-    
+    """S2 Width cut based on diffusion model (arXiv::1102.2865).
+ 
     It should be applicable to data regardless of if it ER or NR; 
     above cS2 = 1e5 pe ERs the acceptance will go down due to track length effects.
 
     Author: Jelle, translation to lax by Chris.
-    -------------------------------------------
-    Tune the diffusion model parameters according to note:
+    
+    Tune the diffusion model parameters based on pax v6.4.2 AmBe data according to note:
     https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:yuehuan:analysis:0sciencerun_s2width_update0#comparison_with_diffusion_model_cut_by_jelle_pax_v642
-    1) w0: 304 -> 350
-    2) 3.6395 -> 3.9656
-    1) and 2) changing according to Fig7 and Fig8 in the note.
     Auther: Yuehuan, 2017-02-27
+    
     """
     version = 1
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -206,7 +206,7 @@ class S2Width(ManyLichen):
 
     Author: Jelle, translation to lax by Chris.
     """
-    version = 0
+    version = 1
 
     def __init__(self):
         self.lichen_list = [self.S2WidthHigh(),
@@ -216,8 +216,8 @@ class S2Width(ManyLichen):
         diffusion_constant = PAX_CONFIG['WaveformSimulator']['diffusion_constant_liquid']
         v_drift = PAX_CONFIG['DEFAULT']['drift_velocity_liquid']
 
-        w0 = 304 * units.ns
-        return np.sqrt(w0 ** 2 - 3.6395 * diffusion_constant * z / v_drift ** 3)
+        w0 = 350 * units.ns
+        return np.sqrt(w0 ** 2 - 3.9656 * diffusion_constant * z / v_drift ** 3)
 
     def subpre(self, df):
         # relative_s2_width


### PR DESCRIPTION
Diffusion parameters update according to Fig 7 and Fig8 in the note below.
1) 304 -> 350
2) 3.6395 -> 3.9656 (To avoid detail study on diffusion constant and electron drift velocity in limit time, just update this parameter here )
After tuning the parameters, the acceptance inside 99% ER band increased a bit, while the rejection power decreased a bit for the outlier events (Table0 and 1). This decreasing may can be compensated by new S1 pattern cut. Suggested to update to the new parameters. 
https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:yuehuan:analysis:0sciencerun_s2width_update0#comparison_with_diffusion_model_cut_by_jelle_pax_v642