### PR TITLE
S2 pattern likelihood cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -340,7 +340,7 @@ class S2SingleScatterSimple(StringLichen):
     version = 0
     string = 'largest_other_s2 < s2 * 0.00832 + 72.3'
 
-    
+
 class S2PatternLikelihood(StringLichen):
     """Reject poorly reconstructed S2s and multiple scatters.
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -339,7 +339,7 @@ class S2SingleScatterSimple(StringLichen):
     """
     version = 0
     string = 'largest_other_s2 < s2 * 0.00832 + 72.3'
-    
+
     
 class S2PatternLikelihood(StringLichen):
     """Reject poorly reconstructed S2s and multiple scatters.

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -208,6 +208,30 @@ class S1PatternLikelihood(Lichen):
         return df
 
 
+class S2PatternLikelihood(Lichen):
+    """Reject poorly reconstructed S2s and multiple scatters.
+
+    Details of the likelihood can be seen in the following note. Here, 98
+    quantile acceptance line estimated with Rn220 data (pax_v6.4.2) is used.
+
+       xenon:xenon1t:analysis:firstresults:s2_pattern_likelihood_cut
+
+    Requires Extended minitrees.
+
+    Contact: Bart Pelssers  <bart.pelssers@fysik.su.se>
+    """
+
+    version = 0
+
+    def pre(self, df):
+        df.loc[:, 'temp'] = 75 + 10*df['s2']**0.45
+        return df
+
+    def _process(self, df):
+        df.loc[:, self.name()] = df['s2_pattern_fit'] < df.temp
+        return df
+
+
 class S1SingleScatter(Lichen):
     """Requires only one valid interaction between the largest S2, and any S1 recorded before it.
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -40,6 +40,7 @@ class AllEnergy(ManyLichen):
             DAQVeto(),
             S1SingleScatter(),
             S1AreaFractionTop(),
+            S2PatternLikelihood(),
         ]
 
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -208,31 +208,6 @@ class S1PatternLikelihood(Lichen):
         df.loc[:, self.name()] = df['s1_pattern_fit'] < df.temp
         return df
 
-
-class S2PatternLikelihood(Lichen):
-    """Reject poorly reconstructed S2s and multiple scatters.
-
-    Details of the likelihood can be seen in the following note. Here, 98
-    quantile acceptance line estimated with Rn220 data (pax_v6.4.2) is used.
-
-       xenon:xenon1t:analysis:firstresults:s2_pattern_likelihood_cut
-
-    Requires Extended minitrees.
-
-    Contact: Bart Pelssers  <bart.pelssers@fysik.su.se>
-    """
-
-    version = 0
-
-    def pre(self, df):
-        df.loc[:, 'temp'] = 75 + 10*df['s2']**0.45
-        return df
-
-    def _process(self, df):
-        df.loc[:, self.name()] = df['s2_pattern_fit'] < df.temp
-        return df
-
-
 class S1SingleScatter(Lichen):
     """Requires only one valid interaction between the largest S2, and any S1 recorded before it.
 
@@ -364,6 +339,22 @@ class S2SingleScatterSimple(StringLichen):
     """
     version = 0
     string = 'largest_other_s2 < s2 * 0.00832 + 72.3'
+    
+    
+class S2PatternLikelihood(StringLichen):
+    """Reject poorly reconstructed S2s and multiple scatters.
+
+    Details of the likelihood can be seen in the following note. Here, 98
+    quantile acceptance line estimated with Rn220 data (pax_v6.4.2) is used.
+
+       xenon:xenon1t:analysis:firstresults:s2_pattern_likelihood_cut
+
+    Requires Extended minitrees.
+
+    Contact: Bart Pelssers  <bart.pelssers@fysik.su.se>
+    """
+    version = 0
+    string = "s2_pattern_fit < 75 + 10 * s2**0.45"
 
 
 class S2Threshold(StringLichen):


### PR DESCRIPTION
To reject poorly position reconstructed S2s and S2s with a double scatter in the hitpattern.
N-1 Acceptance defined on Rn220 sample, 98%.
Note: https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:analysis:firstresults:s2_pattern_likelihood_cut
