### PR TITLE
Tune S2 width cut to get a better acceptance

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -368,9 +368,9 @@ class S2Width(ManyLichen):
 
     xenon:xenon1t:yuehuan:analysis:0sciencerun_s2width_update0#comparison_with_diffusion_model_cut_by_jelle_pax_v642
 
-    Contact: Yuehuan <weiyh@physik.uzh.ch>
+    Contact: Yuehuan <weiyh@physik.uzh.ch>, Jelle <jaalbers@nikhef.nl>
     """
-    version = 1
+    version = 2
 
     def __init__(self):
         self.lichen_list = [self.S2WidthHigh(),
@@ -391,11 +391,11 @@ class S2Width(ManyLichen):
 
     @staticmethod
     def relative_s2_width_bounds(s2, kind='high'):
-        x = 0.3 * np.log10(np.clip(s2, 150, 7000))
+        x = 0.5 * np.log10(np.clip(s2, 150, 4500 if kind == 'high' else 2500))
         if kind == 'high':
-            return 2.3 - x
+            return 3 - x
         elif kind == 'low':
-            return -0.3 + x
+            return -0.9 + x
         raise ValueError("kind must be high or low")
 
     class S2WidthHigh(Lichen):


### PR DESCRIPTION
This updates our S2 width cut with more artisanally tuned bounds:

![newbounds](https://cloud.githubusercontent.com/assets/4354311/23684312/a82d7790-0363-11e7-90ce-e36c39c0425f.png)

(vertical line is the S2=150 pe threshold cut)

This improves the acceptance I get using the waveform simulator:
  * simulate S2s of several sizes at a random depth and xy, 
  * feed to pax
  * Select largest peak in the event and assume it is the S2 we've simulated (it might not be at very low energy due to photoionization-generated single electrons).

![newacc](https://cloud.githubusercontent.com/assets/4354311/23684317/acd1f294-0363-11e7-889e-92c33bf7a5c8.png)

Note the y axis starts at 0.8

```
S2: [    39.47310072,    104.32328065,    167.98300587,    240.48969986,
          340.03392495,    470.75538331,    654.66285814,    911.44622414,
         1270.80358029,   1749.21977098,   2420.81758513,   3352.64857771,
         4627.57160698,   6430.45125895,   8845.1722301 ,  12713.13870829]

Acceptance: [ 0.74348697,  0.946     ,  0.972     ,  0.988     ,  0.984     ,
        0.992     ,  0.992     ,  0.996     ,  0.986     ,  0.992     ,
        0.984     ,  0.984     ,  0.978     ,  0.99      ,  0.994     ,  1.        ]

```
