### PR TITLE
Fix warning with SingleElectronS2s

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -649,10 +649,17 @@ class SingleElectronS2s(Lichen):
                                     fill_value='extrapolate', kind='linear')
 
     def _process(self, df):
+        # Is the event inside the area box considered for this study?
         cond = ((df[self.area_variable] < self.allowed_range_area[0]) &
                 (df[self.area_variable] > self.allowed_range_area[1]) &
                 (df[self.rt_variable] > self.allowed_range_rt[0]) &
                 (df[self.rt_variable] < self.allowed_range_rt[1]))
-        df.loc[:, self.name()] = True    # If outside the studied box, pass the event
-        df.loc[:, self.name()][cond] = df[self.rt_variable][cond] < SingleElectronS2s.bound_v4(df[self.aft_variable][cond])
+
+        # Pass events by default
+        passes = np.ones(len(df), dtype=np.bool)
+
+        # Reject events inside the box that don't pass the bound
+        passes[cond] = df[self.rt_variable][cond] < SingleElectronS2s.bound_v4(df[self.aft_variable][cond])
+
+        df.loc[:, self.name()] = passes
         return df


### PR DESCRIPTION
Currently when using SingleElectronS2s you get a pandas warning:

```
/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/lax-0.9.1-py3.4.egg/lax/lichens/sciencerun0.py:657: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
  df.loc[:, self.name()][cond] = df[self.rt_variable][cond] < SingleElectronS2s.bound_v4(df[self.aft_variable][cond])
```

Usually when I got this warning, some things started happening I didn't expect. The chained indexing stuff looks pretty scary in the docs... This should remove the warning (or break everything, I didn't actually test it of course)