### PR TITLE
Update s2single parameters for pax v6.4.2

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -465,19 +465,19 @@ class S2SingleScatter(Lichen):
     Contact: Tianyu Zhu <tz2263@columbia.edu>
     """
 
-    version = 2
+    version = 3
     allowed_range = (0, np.inf)
     variable = 'temp'
 
     @classmethod
     def other_s2_bound(cls, s2_area):
-        rescaled_s2_0 = s2_area * 0.00832 + 72.3
-        rescaled_s2_1 = s2_area * 0.03 - 109
+        linear_func_of_s2_0 = s2_area * 0.01 + 90.0
+        linear_func_of_s2_1 = s2_area * 0.025 + 766.0
 
-        another_term_0 = 1 / (np.exp((s2_area - 23300) * 5.91e-4) + 1)
-        another_term_1 = 1 / (np.exp((23300 - s2_area) * 5.91e-4) + 1)
+        fermi_dirac_coef_0 = 1 / (np.exp((s2_area - 26000) * 6.0e-4) + 1)
+        fermi_dirac_coef_1 = 1 / (np.exp((26000 - s2_area) * 6.0e-4) + 1)
 
-        return rescaled_s2_0 * another_term_0 + rescaled_s2_1 * another_term_1
+        return linear_func_of_s2_0 * fermi_dirac_coef_0 + linear_func_of_s2_1 * fermi_dirac_coef_1
 
     def _process(self, df):
         df.loc[:, self.name()] = df.largest_other_s2 < self.other_s2_bound(df.s2)
@@ -494,8 +494,8 @@ class S2SingleScatterSimple(StringLichen):
 
     Contact: Tianyu Zhu <tz2263@columbia.edu>
     """
-    version = 0
-    string = 'largest_other_s2 < s2 * 0.00832 + 72.3'
+    version = 1
+    string = 'largest_other_s2 < s2 * 0.01 + 90.0'
 
 
 class S2PatternLikelihood(StringLichen):


### PR DESCRIPTION
This updates the s2single parameters, adapting to pax v6.4.2. The old s2single is suffering from low acceptance at low s2 in this pax version and might also the later updates.
![image](https://cloud.githubusercontent.com/assets/16232525/23775212/8866f27c-04f5-11e7-98e1-38c22b3b6f69.png)
This improves the acceptance but at the same thin would expect a drop in rejection power.
![image](https://cloud.githubusercontent.com/assets/16232525/23775237/aea57cf6-04f5-11e7-89b7-f80f493b128f.png)
![image](https://cloud.githubusercontent.com/assets/16232525/23775243/b304cacc-04f5-11e7-9254-498314782392.png)
![image](https://cloud.githubusercontent.com/assets/16232525/23775246/b737764e-04f5-11e7-922a-05e0fc6f5663.png)
The number in the parenthesis are average over the energy range. And s2 axis start from 200 pe and end at 5000 pe.

