### PR TITLE
S1 area fraction top update

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -11,9 +11,6 @@ import pytz
 import numpy as np
 from pax import units, configuration
 
-from scipy.interpolate import RectBivariateSpline
-from scipy.stats import binom_test
-from scipy import interpolate
 import json
 
 PAX_CONFIG = configuration.load_configuration('XENON1T')
@@ -616,41 +613,25 @@ class S2Width(ManyLichen):
             return df
 
 
-class S1AreaFractionTop(RangeLichen):
+class S1AreaFractionTop(StringLichen):
     '''S1 area fraction top cut
 
-    Uses scipy.stats.binom_test to compute a p-value based on the
+    Uses a modified version of scipy.stats.binom_test to compute a p-value based on the
     observed number of s1 photons in the top array, given the expected
-    probability that a photon at the event's (r,z) makes it to the top array.
+    probability that a photon at the event's (x,y,z) makes it to the top array.
+    Modifications made to original algorithm implemented in pax increase sensitivity for small s1s
+
+    Requires S1AFT minitrees
 
     Uses a 3D map generated with Kr83m 32 keV line
 
     note: https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:darryl:xe1t_s1_aft_map
 
-    Author: Darryl Masson, dmasson@purdue.edu
+    Contact: Darryl Masson, dmasson@purdue.edu
     '''
 
-    version = 1
-    variable = 'pvalue_s1_area_fraction_top'
-    allowed_range = (1e-4, 1 + 1e-7)  # must accept p-value = 1.0 with a < comparison
-
-    def __init__(self):
-        aftmap_filename = os.path.join(DATA_DIR,
-                                       's1_aft_rz_02Mar2017.json')
-        with open(aftmap_filename) as data_file:
-            data = json.load(data_file)
-        r_pts = np.array(data['r_pts'])
-        z_pts = np.array(data['z_pts'])
-        aft_vals = np.array([data['map'][i*len(z_pts):(i+1)*len(z_pts)] for i in range(len(r_pts))]) # unpack 1d array to 2d
-        self.aft_map = RectBivariateSpline(r_pts,z_pts,aft_vals)
-
-    def pre(self, df):
-        df.loc[:, self.variable] = df.apply(lambda row: binom_test(np.round(row['s1_area_fraction_top'] * row['s1']),
-                                                                   np.round(row['s1']),
-                                                                   self.aft_map(np.sqrt(row['x']**2 + row['y']**2),
-                                                                                row['z'])[0,0]),
-                                            axis=1)
-        return df
+    version = 2
+    string = "s1_area_fraction_top_probability > 1e-4"
 
 
 class PreS2Junk(StringLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -638,9 +638,9 @@ class S1AreaFractionTop(RangeLichen):
 
     variable = 's1_area_fraction_top_probability'
     allowed_range = (1e-4, 1 + 1e-7)  # must accept p-value = 1.0 with a < comparison
+    version = 2
 
     def __init__(self):
-        version = 2
         aftmap_filename = os.path.join(DATA_DIR, 's1_aft_rz_02Mar2017.json')
         with open(aftmap_filename) as data_file:
             data = json.load(data_file)
@@ -654,8 +654,8 @@ class S1AreaFractionTop(RangeLichen):
             df.loc[:, self.variable] = df.apply(lambda row: binom_test(np.round(row['s1_area_fraction_top'] * row['s1']),
                                                                        np.round(row['s1']),
                                                                        self.aft_map(np.sqrt(row['x']**2 + row['y']**2),
-                                                                                    row['z'])[0,0]),
-                                                                       axis=1)
+                                                                                            row['z'])[0,0]),
+                                                axis=1)
         return df
 
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -10,7 +10,6 @@ import pytz
 
 import numpy as np
 from pax import units, configuration
-from pax import __version__ as pax_version
 
 from scipy.interpolate import RectBivariateSpline
 from scipy.stats import binom_test
@@ -617,7 +616,7 @@ class S2Width(ManyLichen):
             return df
 
 
-class S1AreaFractionTop(StringLichen):
+class S1AreaFractionTop(RangeLichen):
     '''S1 area fraction top cut
 
     Uses a modified version of scipy.stats.binom_test to compute a p-value based on the
@@ -627,11 +626,12 @@ class S1AreaFractionTop(StringLichen):
     For pax < v6.6.0 computes p-value live, otherwise loads it from disk. Computation done here is
     not as accurate as in pax > v6.6.5
 
-    Requires Extended minitrees >= v0.0.4
+    Ideally requires Extended minitrees >= v0.0.4
 
     Uses a 3D map generated with Kr83m 32 keV line
 
     note: https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:darryl:xe1t_s1_aft_map
+    also https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:darryl:s1_aft_update
 
     Contact: Darryl Masson, dmasson@purdue.edu
     '''
@@ -640,21 +640,17 @@ class S1AreaFractionTop(StringLichen):
     allowed_range = (1e-4, 1 + 1e-7)  # must accept p-value = 1.0 with a < comparison
 
     def __init__(self):
-        self.min_pax_version = 660  # before v6.6.0 p-value not calculated
-        if int(pax_version.replace('.', '')) < self.min_pax_version:
-            version = 1
-            aftmap_filename = os.path.join(DATA_DIR, 's1_aft_rz_02Mar2017.json')
-            with open(aftmap_filename) as data_file:
-                data = json.load(data_file)
-            r_pts = np.array(data['r_pts'])
-            z_pts = np.array(data['z_pts'])
-            aft_vals = np.array([data['map'][i*len(z_pts):(i+1)*len(z_pts)] for i in range(len(r_pts))]) # unpack 1d array to 2d
-            self.aft_map = RectBivariateSpline(r_pts, z_pts, aft_vals)
-        else:
-            version = 2
+        version = 2
+        aftmap_filename = os.path.join(DATA_DIR, 's1_aft_rz_02Mar2017.json')
+        with open(aftmap_filename) as data_file:
+            data = json.load(data_file)
+        r_pts = np.array(data['r_pts'])
+        z_pts = np.array(data['z_pts'])
+        aft_vals = np.array(data['map']).reshape(len(r_pts), len(z_pts))
+        self.aft_map = RectBivariateSpline(r_pts, z_pts, aft_vals)
 
     def pre(self, df):
-        if version == 1:
+        if self.variable not in df:
             df.loc[:, self.variable] = df.apply(lambda row: binom_test(np.round(row['s1_area_fraction_top'] * row['s1']),
                                                                        np.round(row['s1']),
                                                                        self.aft_map(np.sqrt(row['x']**2 + row['y']**2),

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -638,9 +638,9 @@ class S1AreaFractionTop(StringLichen):
 
     variable = 's1_area_fraction_top_probability'
     allowed_range = (1e-4, 1 + 1e-7)  # must accept p-value = 1.0 with a < comparison
-    self.min_pax_version = 660  # before v6.6.0 p-value not calculated
 
     def __init__(self):
+        self.min_pax_version = 660  # before v6.6.0 p-value not calculated
         if int(pax_version.replace('.', '')) < self.min_pax_version:
             version = 1
             aftmap_filename = os.path.join(DATA_DIR, 's1_aft_rz_02Mar2017.json')

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -12,6 +12,9 @@ import numpy as np
 from pax import units, configuration
 from pax import __version__ as pax_version
 
+from scipy.interpolate import RectBivariateSpline
+from scipy.stats import binom_test
+from scipy import interpolate
 import json
 
 PAX_CONFIG = configuration.load_configuration('XENON1T')


### PR DESCRIPTION
The long-awaited update for the S1AreaFractionTop cut. Where the necessary variable has already been computed (pax >= v6.6.0) it uses that, otherwise it computes it as normal. This cut will be backwards compatible for SR0, until it is appropriate to remove this feature.

Worth mentioning, this PR shouldn't be merged until https://github.com/XENON1T/hax/pull/102 is merged and the Extended minitrees regrown.