### PR TITLE
LowEnergyRn220 accidentally removes DAQVeto cut

### DIFF
--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -55,7 +55,7 @@ class LowEnergyRn220(AllEnergy):
         self.lichen_list[1] = S1LowEnergyRange()
 
         # Use a simpler single scatter cut
-        self.lichen_list[5] = S2SingleScatterSimple()
+        self.lichen_list[4] = S2SingleScatterSimple()
 
         self.lichen_list += [
             S1PatternLikelihood(),


### PR DESCRIPTION
Fix typo in 'replace' call that called the wrong array index. Presumably the parent lichen list was changed, bumping indices. We should think of a better way to do this.