### PR TITLE
Allow importing lax.lichens.sciencerun1

### DIFF
--- a/lax/lichens/__init__.py
+++ b/lax/lichens/__init__.py
@@ -1,2 +1,2 @@
 """Module containing all lichen definitions"""
-from . import sciencerun0
+from . import sciencerun0, sciencerun1


### PR DESCRIPTION
This makes it possible to use the science run 1 lichens by doing import lax (now need to explicitly import lax.lichens.sciencerun1)