### PR TITLE
correcting one parameter in S2 width cut for SR1

### DIFF
--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -200,7 +200,7 @@ class S2Width(ManyLichen):
         v_drift = 1.335 * (units.um) / units.ns
         GausSigmaToR50 = 1.349
 
-        EffectivePar = 1.16
+        EffectivePar = 0.925
         Sigma_0 = 229.58 * units.ns
         return GausSigmaToR50 * np.sqrt(Sigma_0 ** 2 - EffectivePar *2 * diffusion_constant * z / v_drift ** 3)
 


### PR DESCRIPTION
EffectivePar: 1.16 -> 0.925

https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:yuehuan:analysis:1sciencerun_s2width#appendix_3bug_of_this_cut_in_laxlichenssr1