### PR TITLE
Removed the Calibration Source Classes

### DIFF
--- a/bin/laxer
+++ b/bin/laxer
@@ -73,8 +73,6 @@ def main():
     elif args.SCIENCERUN == 1:
         LAX_LICHENS = [sciencerun1.AllEnergy(),
                        sciencerun1.LowEnergyRn220(),
-                       sciencerun1.LowEnergyAmBe(),
-                       sciencerun1.LowEnergyNG(),
                        sciencerun1.LowEnergyBackground()]
 
     TREENAME = 'tree'

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -36,7 +36,6 @@ class AllEnergy(ManyLichen):
             DAQVeto(),
             S1SingleScatter(),
             S2PatternLikelihood(),
-            S2Tails(),
             InteractionPeaksBiggest()
         ]
 
@@ -69,42 +68,17 @@ class LowEnergyRn220(AllEnergy):
 class LowEnergyBackground(LowEnergyRn220):
     """Select background events with cs1<200
 
-    This is the list that we'll use for the actual DM search. Additionally to the
-    LowEnergyRn220 list it contains the PreS2Junk
+    This is the list that we'll use for the actual DM search. In addition to the
+    LowEnergyRn220 list, it contains S2Tails and PreS2Junk.
     """
 
     def __init__(self):
         LowEnergyRn220.__init__(self)
 
         self.lichen_list += [
+            S2Tails(),
             PreS2Junk(),
         ]
-
-
-class LowEnergyAmBe(LowEnergyRn220):
-    """Select AmBe events with cs1<200 with appropriate cuts
-
-    It is the same as the LowEnergyRn220 cuts, except uses an AmBe fiducial.
-    """
-
-    def __init__(self):
-        LowEnergyRn220.__init__(self)
-
-        # Replaces Fiducial
-        self.lichen_list[0] = AmBeFiducial()
-
-
-class LowEnergyNG(LowEnergyRn220):
-    """Select AmBe events with cs1<200 with appropriate cuts
-
-    It is the same as the LowEnergyRn220 cuts, except uses an AmBe fiducial.
-    """
-
-    def __init__(self):
-        LowEnergyRn220.__init__(self)
-
-        # Replaces Fiducial
-        self.lichen_list[0] = NGFiducial()
 
 
 DAQVeto = sciencerun0.DAQVeto

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -36,6 +36,7 @@ class AllEnergy(ManyLichen):
             DAQVeto(),
             S1SingleScatter(),
             S2PatternLikelihood(),
+            S2Tails(),
             InteractionPeaksBiggest()
         ]
 
@@ -76,7 +77,6 @@ class LowEnergyBackground(LowEnergyRn220):
         LowEnergyRn220.__init__(self)
 
         self.lichen_list += [
-            S2Tails(),
             PreS2Junk(),
         ]
 


### PR DESCRIPTION
I removed the 'LowEnergyAmBe' and 'LowEnergyNG' classes but left the original definitions of the FV's designed for the calibration sources, in case someone wants to use them in the future. I also moved S2Tails from 'AllEnergy' to 'LowEnergyBackground', where it belongs.