### PR TITLE
Slight tuning of S2PatternLikelihood for SR0

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -538,10 +538,10 @@ class S2PatternLikelihood(StringLichen):
 
     Requires Extended minitrees.
 
-    Contact: Bart Pelssers  <bart.pelssers@fysik.su.se>
+    Contact: Bart Pelssers  <bart.pelssers@fysik.su.se> Tianyu Zhu  <tz2263@columbia.edu>
     """
-    version = 0
-    string = "s2_pattern_fit < 75 + 10 * s2**0.45"
+    version = 1
+    string = "s2_pattern_fit < 0.0390*s2 + 609*s2**0.0602 - 666"
 
 
 class S2Threshold(StringLichen):


### PR DESCRIPTION
Using the same method for sr1 pattern cut tuning, we slightly change the cut, so that it won't lose acceptance with large s2.
<img width="440" alt="pattern_tuning_8a" src="https://user-images.githubusercontent.com/16232525/31963548-0b47dba6-b8cf-11e7-98e6-e736cca56a2a.png">
<img width="492" alt="pattern_tuning_8b" src="https://user-images.githubusercontent.com/16232525/31963549-0b5d21dc-b8cf-11e7-862d-f43bb3dd52b3.png">
But in 200 ~ 6000 this change would almost give the same result as the original one.
