### PR TITLE
More FV updates

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -33,7 +33,7 @@ class AllEnergy(ManyLichen):
 
     def __init__(self):
         self.lichen_list = [
-            FiducialCylinder1T(),
+            FiducialCylinder1p3T(),
             InteractionExists(),
             S2Threshold(),
             InteractionPeaksBiggest(),
@@ -191,7 +191,7 @@ class S2Tails(Lichen):
         return df
 
 
-class FiducialCylinder1T(StringLichen):
+class FiducialCylinder1T_TPF2dFDC(StringLichen):
     """Fiducial volume cut.
 
     The fidicual volume cut defines the region in depth and radius that we
@@ -201,6 +201,8 @@ class FiducialCylinder1T(StringLichen):
     This version of the cut is based pax v6.4 bg run 0 data. See the
     note first results fiducial volume note for the study of the definition.
 
+    (Used to be "FiducialCylinder1T" version 4.)
+
     Contact: Sander breur <sanderb@nikhef.nl>
 
     """
@@ -209,6 +211,21 @@ class FiducialCylinder1T(StringLichen):
 
     def pre(self, df):
         df.loc[:, 'r'] = np.sqrt(df['x'] * df['x'] + df['y'] * df['y'])
+        return df
+
+
+class FiducialCylinder1T(StringLichen):
+    """Fiducial volume cut using NN 3D FDC instead of TPF 2D FDC above.
+
+    Temporary/under development, for preliminary comparisons to 
+    FiducialCylinder1p3T below.
+
+    """
+    version = 5
+    string = "(-92.9 < z_3d_nn) & (z_3d_nn < -9) & (sqrt(x_3d_nn*x_3d_nn + y_3d_nn*y_3d_nn) < 36.94)"
+
+    def pre(self, df):
+        df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn'] * df['x_3d_nn'] + df['y_3d_nn'] * df['y_3d_nn'])
         return df
 
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -9,7 +9,7 @@ import os
 import pytz
 
 import numpy as np
-from pax import units, configuration
+from pax import units
 
 from scipy.interpolate import RectBivariateSpline
 from scipy.stats import binom_test
@@ -217,7 +217,7 @@ class FiducialCylinder1T_TPF2dFDC(StringLichen):
 class FiducialCylinder1T(StringLichen):
     """Fiducial volume cut using NN 3D FDC instead of TPF 2D FDC above.
 
-    Temporary/under development, for preliminary comparisons to 
+    Temporary/under development, for preliminary comparisons to
     FiducialCylinder1p3T below.
 
     """

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -7,7 +7,7 @@ This includes all current definitions of the cuts for the second science run
 import inspect
 import os
 import numpy as np
-from pax import units, configuration
+from pax import units
 
 from lax.lichen import Lichen, RangeLichen, ManyLichen, StringLichen
 from lax.lichens import sciencerun0

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -27,7 +27,7 @@ class AllEnergy(ManyLichen):
 
     def __init__(self):
         self.lichen_list = [
-            FiducialCylinder1T(),
+            FiducialCylinder1p3T(),
             InteractionExists(),
             S2Threshold(),
             S2AreaFractionTop(),
@@ -96,6 +96,8 @@ class S2Tails(Lichen):
     def _process(self, df):
         df.loc[:, self.name()] = (df['s2_over_tdiff'] < 0.025)
         return df
+
+FiducialCylinder1T_TPF2dFDC = sciencerun0.FiducialCylinder1T_TPF2dFDC
 
 FiducialCylinder1T = sciencerun0.FiducialCylinder1T
 


### PR DESCRIPTION
1. Make ```FiducialCylinder1p3T``` the new default FV (requested by @feigaodm)

2. Switch ```FiducialCylinder1T``` to use NN-3dFDC for consistency with ```FiducialCylinder1p3T``` and future comparisons

3. And rename old TPF-2dFDC-based FV to ```FiducialCylinder1T_TPF2dFDC``` to reproduce published analysis and comparisons