### PR TITLE
Revive NR source classes

### DIFF
--- a/bin/laxer
+++ b/bin/laxer
@@ -73,6 +73,8 @@ def main():
     elif args.SCIENCERUN == 1:
         LAX_LICHENS = [sciencerun1.AllEnergy(),
                        sciencerun1.LowEnergyRn220(),
+                       sciencerun1.LowEnergyAmBe(),
+                       sciencerun1.LowEnergyNG(),
                        sciencerun1.LowEnergyBackground()]
 
     TREENAME = 'tree'

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -90,14 +90,11 @@ class LowEnergyBackground(LowEnergyRn220):
 class LowEnergyAmBe(LowEnergyRn220):
     """Select AmBe events with cs1<200 with appropriate cuts
 
-    It is the same as the LowEnergyRn220 cuts, except uses an AmBe fiducial.
+    It is the same as the LowEnergyRn220 cuts.
     """
 
     def __init__(self):
         LowEnergyRn220.__init__(self)
-
-        # Replaces Fiducial
-        self.lichen_list[0] = AmBeFiducial()
 
 
 class DAQVeto(ManyLichen):

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -79,6 +79,25 @@ class LowEnergyBackground(LowEnergyRn220):
             PreS2Junk(),
         ]
 
+class LowEnergyAmBe(LowEnergyRn220):
+    """Select AmBe events with cs1<200 with appropriate cuts
+
+    It is the same as the LowEnergyRn220 cuts.
+    """
+
+    def __init__(self):
+        LowEnergyRn220.__init__(self)
+ 
+ 
+ class LowEnergyNG(LowEnergyRn220):
+    """Select NG events with cs1<200 with appropriate cuts
+
+    It is the same as the LowEnergyRn220 cuts.
+    """
+ 
+    def __init__(self):
+        LowEnergyRn220.__init__(self)
+
 
 DAQVeto = sciencerun0.DAQVeto
 

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -89,7 +89,7 @@ class LowEnergyAmBe(LowEnergyRn220):
         LowEnergyRn220.__init__(self)
  
  
- class LowEnergyNG(LowEnergyRn220):
+class LowEnergyNG(LowEnergyRn220):
     """Select NG events with cs1<200 with appropriate cuts
 
     It is the same as the LowEnergyRn220 cuts.

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -87,14 +87,14 @@ class LowEnergyAmBe(LowEnergyRn220):
 
     def __init__(self):
         LowEnergyRn220.__init__(self)
- 
- 
+
+
 class LowEnergyNG(LowEnergyRn220):
     """Select NG events with cs1<200 with appropriate cuts
 
     It is the same as the LowEnergyRn220 cuts.
     """
- 
+
     def __init__(self):
         LowEnergyRn220.__init__(self)
 


### PR DESCRIPTION
Reinstate ```LowEnergyAmBe``` and ```LowEnergyNG``` for backward compatibility according to https://github.com/XENON1T/lax/issues/95. 

Still remove ```distance_to_source``` (```AmBeFiducial```, ```NGFiducial```) cuts to maintain high stats, and since ER contamination is included in the calibration fits.