### PR TITLE
Add super elliptical fiducial volumes for testing in SR1

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -240,7 +240,7 @@ class FiducialCylinder1p3T(StringLichen):
     def pre(self, df):
         df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn'] * df['x_3d_nn'] + df['y_3d_nn'] * df['y_3d_nn'])
         return df
-      
+
 fvconfigs = [
     # Mass (kg), (z0, vz, p, vr2)
     (1000, (-57.58, 31.25, 4.20, 1932.53)),

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -240,6 +240,69 @@ class FiducialCylinder1p3T(StringLichen):
     def pre(self, df):
         df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn'] * df['x_3d_nn'] + df['y_3d_nn'] * df['y_3d_nn'])
         return df
+      
+fvconfigs = [
+    # Mass (kg), (z0, vz, p, vr2)
+    (1000, (-57.58, 31.25, 4.20, 1932.53)),
+    (1025, (-57.29, 31.65, 3.71, 1987.85)),
+    (1050, (-62.25, 33.89, 3.08, 1969.68)),
+    (1075, (-59.73, 35.58, 2.97, 1938.27)),
+    (1100, (-58.36, 36.97, 2.67, 1951.06)),
+    (1125, (-58.57, 37.36, 2.78, 1953.64)),
+    (1150, (-58.71, 37.37, 3.25, 1934.94)),
+    (1175, (-57.35, 38.17, 3.14, 1944.21)),
+    (1200, (-56.44, 39.23, 2.88, 1961.09)),
+    (1225, (-55.81, 40.30, 2.80, 1969.58)),
+    (1250, (-55.44, 40.70, 3.21, 1936.89)),
+    (1275, (-54.62, 41.19, 3.29, 1937.40)),
+    (1300, (-54.04, 42.08, 2.56, 2041.03)),
+    (1325, (-53.31, 42.52, 2.85, 2005.24)),
+    (1350, (-51.63, 43.64, 3.15, 1949.59)),
+    (1375, (-51.85, 44.07, 2.87, 2003.40)),
+    (1400, (-52.22, 43.88, 3.88, 1949.48)),
+    (1425, (-50.87, 45.22, 2.75, 2046.11)),
+    (1450, (-51.66, 43.60, 3.58, 2053.80)),
+    (1475, (-51.99, 43.92, 3.88, 2044.43)),
+    (1500, (-52.50, 43.69, 4.31, 2059.53)),
+    (1525, (-51.51, 44.67, 3.68, 2093.78)),
+    (1550, (-51.13, 45.04, 3.98, 2088.21)),
+    (1575, (-49.44, 46.67, 3.43, 2091.66)),
+    (1600, (-50.15, 45.95, 3.77, 2126.11)),
+    (1625, (-50.06, 45.99, 4.32, 2119.37)),
+    (1650, (-50.16, 45.95, 4.67, 2137.15)),
+    (1675, (-49.10, 47.05, 4.53, 2128.00)),
+    (1700, (-49.54, 46.51, 6.10, 2129.72)),
+]
+
+class FiducialTestEllips(StringLichen):
+    """TESTFiducial volume cut using NN 3D FDC.
+    Temporary/under development, for preliminary
+    comparisons between the different masses. For every mass
+    in the fv_config keys a FiducialTestEllips<mass> is made.
+    For more info on the construction of the FV see:
+    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:fiducial_volume:optimized_ellips
+    sanderb@nikhef.nl
+    """
+    version = 1
+    parameter_symbols = tuple('z0 vz p vr2'.split())
+    parameter_values = None   # Will be tuple of parameter values
+    string = "((( (((z_3d_nn-@z0)**2)**0.5) /@vz)**@p)+ (r_3d_nn**2/@vr2)**@p) < 1"
+    
+    def _process(self, df):
+        bla = dict(zip(self.parameter_symbols, self.parameter_values))
+        df.loc[:, self.name()] = df.eval(self.string,
+                                         global_dict=bla)
+        return df
+    
+    def pre(self, df):
+        df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn']**2 + df['y_3d_nn']**2)
+        return df
+
+for mass, params in FvConfigs:
+    name = 'FiducialTestEllips' + str(int(mass))
+    c = type(name, (FiducialTestEllips,), dict())
+    c.parameter_values = params
+    locals()[name] = c
 
 
 class FiducialFourLeafClover1250kg(StringLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -241,7 +241,8 @@ class FiducialCylinder1p3T(StringLichen):
         df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn'] * df['x_3d_nn'] + df['y_3d_nn'] * df['y_3d_nn'])
         return df
 
-fvconfigs = [
+
+FV_CONFIGS = [
     # Mass (kg), (z0, vz, p, vr2)
     (1000, (-57.58, 31.25, 4.20, 1932.53)),
     (1025, (-57.29, 31.65, 3.71, 1987.85)),
@@ -274,6 +275,7 @@ fvconfigs = [
     (1700, (-49.54, 46.51, 6.10, 2129.72)),
 ]
 
+
 class FiducialTestEllips(StringLichen):
     """TESTFiducial volume cut using NN 3D FDC.
     Temporary/under development, for preliminary
@@ -287,18 +289,19 @@ class FiducialTestEllips(StringLichen):
     parameter_symbols = tuple('z0 vz p vr2'.split())
     parameter_values = None   # Will be tuple of parameter values
     string = "((( (((z_3d_nn-@z0)**2)**0.5) /@vz)**@p)+ (r_3d_nn**2/@vr2)**@p) < 1"
-    
+
     def _process(self, df):
         bla = dict(zip(self.parameter_symbols, self.parameter_values))
         df.loc[:, self.name()] = df.eval(self.string,
                                          global_dict=bla)
         return df
-    
+
     def pre(self, df):
         df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn']**2 + df['y_3d_nn']**2)
         return df
 
-for mass, params in FvConfigs:
+
+for mass, params in FV_CONFIGS:
     name = 'FiducialTestEllips' + str(int(mass))
     c = type(name, (FiducialTestEllips,), dict())
     c.parameter_values = params

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -122,7 +122,7 @@ FiducialCylinder1T = sciencerun0.FiducialCylinder1T
 
 FiducialCylinder1p3T = sciencerun0.FiducialCylinder1p3T
 
-FvConfigs = [
+fvconfigs = [
     # Mass (kg), (z0, vz, p, vr2)
     (1000, (-57.58, 31.25, 4.20, 1932.53)),
     (1025, (-57.29, 31.65, 3.71, 1987.85)),
@@ -164,7 +164,6 @@ class FiducialTestEllips(StringLichen):
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:fiducial_volume:optimized_ellips
     sanderb@nikhef.nl
     """
-    
     version = 1
     parameter_symbols = tuple('z0 vz p vr2'.split())
     parameter_values = None   # Will be tuple of parameter values

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -167,7 +167,7 @@ class FiducialTestEllips(StringLichen):
     version = 1
     parameter_symbols = tuple('z0 vz p vr2'.split())
     parameter_values = None   # Will be tuple of parameter values
-    string = "((( (((z_3d_nn-@z0)**2)**0.5) /@vz)**@p)+ (r_3d_nn**2/@vr2)**@p) < 1"
+    string = "((((((z_3d_nn-@z0)**2)**0.5)/@vz)**@p)+(r_3d_nn**2/@vr2)**@p)<1"
     
     def _process(self, df):
         bla = dict(zip(self.parameter_symbols, self.parameter_values))

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -79,6 +79,7 @@ class LowEnergyBackground(LowEnergyRn220):
             PreS2Junk(),
         ]
 
+
 class LowEnergyAmBe(LowEnergyRn220):
     """Select AmBe events with cs1<200 with appropriate cuts
 
@@ -116,13 +117,14 @@ class S2Tails(Lichen):
         df.loc[:, self.name()] = (df['s2_over_tdiff'] < 0.025)
         return df
 
+
 FiducialCylinder1T_TPF2dFDC = sciencerun0.FiducialCylinder1T_TPF2dFDC
 
 FiducialCylinder1T = sciencerun0.FiducialCylinder1T
 
 FiducialCylinder1p3T = sciencerun0.FiducialCylinder1p3T
 
-fvconfigs = [
+FV_CONFIGS = [
     # Mass (kg), (z0, vz, p, vr2)
     (1000, (-57.58, 31.25, 4.20, 1932.53)),
     (1025, (-57.29, 31.65, 3.71, 1987.85)),
@@ -155,6 +157,7 @@ fvconfigs = [
     (1700, (-49.54, 46.51, 6.10, 2129.72)),
 ]
 
+
 class FiducialTestEllips(StringLichen):
     """TESTFiducial volume cut using NN 3D FDC.
     Temporary/under development, for preliminary
@@ -168,24 +171,26 @@ class FiducialTestEllips(StringLichen):
     parameter_symbols = tuple('z0 vz p vr2'.split())
     parameter_values = None   # Will be tuple of parameter values
     string = "((((((z_3d_nn-@z0)**2)**0.5)/@vz)**@p)+(r_3d_nn**2/@vr2)**@p)<1"
-    
+
     def _process(self, df):
         bla = dict(zip(self.parameter_symbols, self.parameter_values))
         df.loc[:, self.name()] = df.eval(self.string,
                                          global_dict=bla)
         return df
-    
+
     def pre(self, df):
         df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn']**2 + df['y_3d_nn']**2)
         return df
 
-for mass, params in FvConfigs:
+
+for mass, params in FV_CONFIGS:
     name = 'FiducialTestEllips' + str(int(mass))
     c = type(name, (FiducialTestEllips,), dict())
     c.parameter_values = params
     locals()[name] = c
 
 AmBeFiducial = sciencerun0.AmBeFiducial
+
 
 class NGFiducial(StringLichen):
     """NG Fiducial volume cut.

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -122,7 +122,7 @@ FiducialCylinder1T = sciencerun0.FiducialCylinder1T
 
 FiducialCylinder1p3T = sciencerun0.FiducialCylinder1p3T
 
-fv_configs = [
+FvConfigs = [
     # Mass (kg), (z0, vz, p, vr2)
     (1000, (-57.58, 31.25, 4.20, 1932.53)),
     (1025, (-57.29, 31.65, 3.71, 1987.85)),
@@ -153,13 +153,12 @@ fv_configs = [
     (1650, (-50.16, 45.95, 4.67, 2137.15)),
     (1675, (-49.10, 47.05, 4.53, 2128.00)),
     (1700, (-49.54, 46.51, 6.10, 2129.72)),
-    
 ]
 
 class FiducialTestEllips(StringLichen):
     """TESTFiducial volume cut using NN 3D FDC.
-    Temporary/under development, for preliminary 
-    comparisons between the different masses. For every mass 
+    Temporary/under development, for preliminary
+    comparisons between the different masses. For every mass
     in the fv_config keys a FiducialTestEllips<mass> is made.
     For more info on the construction of the FV see:
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:fiducial_volume:optimized_ellips
@@ -168,12 +167,12 @@ class FiducialTestEllips(StringLichen):
     
     version = 1
     parameter_symbols = tuple('z0 vz p vr2'.split())
-    parameter_values = None   # Will be tuple of parameter values 
+    parameter_values = None   # Will be tuple of parameter values
     string = "((( (((z_3d_nn-@z0)**2)**0.5) /@vz)**@p)+ (r_3d_nn**2/@vr2)**@p) < 1"
     
     def _process(self, df):
         bla = dict(zip(self.parameter_symbols, self.parameter_values))
-        df.loc[:, self.name()] = df.eval(self.string, 
+        df.loc[:, self.name()] = df.eval(self.string,
                                          global_dict=bla)
         return df
     
@@ -181,7 +180,7 @@ class FiducialTestEllips(StringLichen):
         df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn']**2 + df['y_3d_nn']**2)
         return df
 
-for mass, params in fv_configs:
+for mass, params in FvConfigs:
     name = 'FiducialTestEllips' + str(int(mass))
     c = type(name, (FiducialTestEllips,), dict())
     c.parameter_values = params

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -122,6 +122,71 @@ FiducialCylinder1T = sciencerun0.FiducialCylinder1T
 
 FiducialCylinder1p3T = sciencerun0.FiducialCylinder1p3T
 
+fv_configs = [
+    # Mass (kg), (z0, vz, p, vr2)
+    (1000, (-57.58, 31.25, 4.20, 1932.53)),
+    (1025, (-57.29, 31.65, 3.71, 1987.85)),
+    (1050, (-62.25, 33.89, 3.08, 1969.68)),
+    (1075, (-59.73, 35.58, 2.97, 1938.27)),
+    (1100, (-58.36, 36.97, 2.67, 1951.06)),
+    (1125, (-58.57, 37.36, 2.78, 1953.64)),
+    (1150, (-58.71, 37.37, 3.25, 1934.94)),
+    (1175, (-57.35, 38.17, 3.14, 1944.21)),
+    (1200, (-56.44, 39.23, 2.88, 1961.09)),
+    (1225, (-55.81, 40.30, 2.80, 1969.58)),
+    (1250, (-55.44, 40.70, 3.21, 1936.89)),
+    (1275, (-54.62, 41.19, 3.29, 1937.40)),
+    (1300, (-54.04, 42.08, 2.56, 2041.03)),
+    (1325, (-53.31, 42.52, 2.85, 2005.24)),
+    (1350, (-51.63, 43.64, 3.15, 1949.59)),
+    (1375, (-51.85, 44.07, 2.87, 2003.40)),
+    (1400, (-52.22, 43.88, 3.88, 1949.48)),
+    (1425, (-50.87, 45.22, 2.75, 2046.11)),
+    (1450, (-51.66, 43.60, 3.58, 2053.80)),
+    (1475, (-51.99, 43.92, 3.88, 2044.43)),
+    (1500, (-52.50, 43.69, 4.31, 2059.53)),
+    (1525, (-51.51, 44.67, 3.68, 2093.78)),
+    (1550, (-51.13, 45.04, 3.98, 2088.21)),
+    (1575, (-49.44, 46.67, 3.43, 2091.66)),
+    (1600, (-50.15, 45.95, 3.77, 2126.11)),
+    (1625, (-50.06, 45.99, 4.32, 2119.37)),
+    (1650, (-50.16, 45.95, 4.67, 2137.15)),
+    (1675, (-49.10, 47.05, 4.53, 2128.00)),
+    (1700, (-49.54, 46.51, 6.10, 2129.72)),
+    
+]
+
+class FiducialTestEllips(StringLichen):
+    """TESTFiducial volume cut using NN 3D FDC.
+    Temporary/under development, for preliminary 
+    comparisons between the different masses. For every mass 
+    in the fv_config keys a FiducialTestEllips<mass> is made.
+    For more info on the construction of the FV see:
+    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:fiducial_volume:optimized_ellips
+    sanderb@nikhef.nl
+    """
+    
+    version = 1
+    parameter_symbols = tuple('z0 vz p vr2'.split())
+    parameter_values = None   # Will be tuple of parameter values 
+    string = "((( (((z_3d_nn-@z0)**2)**0.5) /@vz)**@p)+ (r_3d_nn**2/@vr2)**@p) < 1"
+    
+    def _process(self, df):
+        bla = dict(zip(self.parameter_symbols, self.parameter_values))
+        df.loc[:, self.name()] = df.eval(self.string, 
+                                         global_dict=bla)
+        return df
+    
+    def pre(self, df):
+        df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn']**2 + df['y_3d_nn']**2)
+        return df
+
+for mass, params in fv_configs:
+    name = 'FiducialTestEllips' + str(int(mass))
+    c = type(name, (FiducialTestEllips,), dict())
+    c.parameter_values = params
+    locals()[name] = c
+
 AmBeFiducial = sciencerun0.AmBeFiducial
 
 class NGFiducial(StringLichen):


### PR DESCRIPTION
This commit adds the code to test the 31 optimized super elliptical FV shapes for testing. The values and construction of the shapes can be found in: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:fiducial_volume:optimized_ellips

An analyst can now use LAX to do:
FiducialTestEllips1000().process(df) to add the Boolean row for a 1000 kg super ellips. Or do FiducialTestEllips1425().process(df) for the 1425 kg super ellips. All available fiducial volumes are between 1000-1700 kg in steps of 25 kg. 

To keep the code clean I chose a method (thanks Jelle) that builds all classes from a single list of inputs instead of copy pasting 31 different classes with only different values. The class name is changed for every mass to make it clear to the analyst what they are using.

Enjoy!