### PR TITLE
Update S1PatternLikelihood Definition

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -470,7 +470,7 @@ class S1MaxPMT(StringLichen):
     string = "s1_largest_hit_area < 0.052 * s1 + 4.15"
 
 
-class S1PatternLikelihood(Lichen):
+class S1PatternLikelihood(StringLichen):
     """Reject accidendal coicident events from lone s1 and lone s2.
 
     Details of the likelihood and cut definitions can be seen in the following notes.


### PR DESCRIPTION
The cut needed to be redefined as 'StringLichen' (rather than 'Lichen') after the recent change in lax 1.2.2.