### PR TITLE
Add cut for Misidentified krypton S1

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -823,3 +823,14 @@ class MuonVeto(StringLichen):
 
     version = 1
     string = "nearest_muon_veto_trigger < -2000000 | nearest_muon_veto_trigger > 3000000"
+
+class KryptonMisIdS1(StringLichen):
+    """Remove events where the 32 keV S1 of Kr83m decay is identified as an S2.
+    These events appear above the ER band since the S1 is from the 9 keV decay
+    but the S2 is combined for a 41 keV event.
+    See the note:
+    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:adam:inelastic:cuts:kr_contamination:mis_ided_s1
+    Contact: Adam Brown <abrown@physik.uzh.ch>
+    """
+    version = 0
+    string = "largest_other_s2 < 100 | largest_other_s2_delay_main_s1 < -3000 | largest_other_s2_delay_main_s1 > 0"

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -43,7 +43,8 @@ class AllEnergy(ManyLichen):
             S1SingleScatter(),
             S2PatternLikelihood(),
             S2Tails(),
-            MuonVeto()
+            MuonVeto(),
+            KryptonMisIdS1()
         ]
 
 

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -37,7 +37,8 @@ class AllEnergy(ManyLichen):
             S2PatternLikelihood(),
             S2Tails(),
             InteractionPeaksBiggest(),
-            MuonVeto()
+            MuonVeto(),
+            KryptonMisIdS1()
         ]
 
 
@@ -311,3 +312,4 @@ S1AreaFractionTop = sciencerun0.S1AreaFractionTop
 
 PreS2Junk = sciencerun0.PreS2Junk
 
+KryptonMisIdS1 = sciencerun0.KryptonMisIdS1


### PR DESCRIPTION
Removes events where the first (32 keV) S1 of Kr83m decay is incorrectly classified as an S2.

Cuts based on time between the main S1 and the second-largest-S2 and the size of the second-largest-S2. The exact cut string is `largest_other_s2 < 100 | largest_other_s2_delay_main_s1 < -3000 | largest_other_s2_delay_main_s1 > 0`.

More information in the note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:adam:inelastic:cuts:kr_contamination:mis_ided_s1