### PR TITLE
Remove S2Tails (duplicate); SR0

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -92,8 +92,7 @@ class LowEnergyBackground(LowEnergyRn220):
         LowEnergyRn220.__init__(self)
 
         self.lichen_list += [
-            PreS2Junk(),
-            S2Tails()
+            PreS2Junk()
         ]
 
 


### PR DESCRIPTION
Removed S2 Tails from LowEnergyBackground since it already exists in AllEnergy. I have run into a problem where S2PatternLikelihood no longer shows up in the list of cuts, but S2Tails is listed twice.