### PR TITLE
MV cut update to account for the coverage

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -14,7 +14,6 @@ from pax import units
 from scipy.stats import chi2
 from scipy.interpolate import RectBivariateSpline
 from scipy.stats import binom_test
-from scipy import interpolate
 import json
 
 from lax.lichen import Lichen, RangeLichen, ManyLichen, StringLichen
@@ -771,9 +770,10 @@ class MuonVeto(StringLichen):
     Contact: Andrea Molinario <andrea.molinario@lngs.infn.it>
     """
 
-    version = 1
-    string = "(nearest_muon_veto_trigger < -2e6 & nearest_muon_veto_trigger > -2e10) | 
-                (nearest_muon_veto_trigger > 3e6 & nearest_muon_veto_trigger < 2e10)"
+    version = 2
+    string = ("(nearest_muon_veto_trigger < -2e6 & nearest_muon_veto_trigger > -2e10) | "
+              "(nearest_muon_veto_trigger > 3e6 & nearest_muon_veto_trigger < 2e10)"
+              )
 
 
 class KryptonMisIdS1(StringLichen):
@@ -820,7 +820,7 @@ class PosDiff(Lichen):
 
     def _process(self, df):
         df.loc[:, self.name()] = (((df['x_observed_nn'] - df['x_observed_tpf'])**2 +
-                                  (df['y_observed_nn'] - df['y_observed_tpf'])**2 < 6) &
+                                   (df['y_observed_nn'] - df['y_observed_tpf'])**2 < 6) &
                                   (df['r_observed_nn']**2 - df['r_observed_tpf']**2 > -80) &
                                   (df['r_observed_nn']**2 - df['r_observed_tpf']**2 < 140))
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -765,13 +765,15 @@ class MuonVeto(StringLichen):
     and the nearest MV trigger.
     The event is excluded if the nearest MV trigger falls in a [-2ms,+3ms] time window
     with respect to the reference position.
+    It also excludes events when MV was not working (abs(nearest_muon_veto_trigger)>20 s).
     It requires Proximity minitrees.
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:mv_cut_sr1
     Contact: Andrea Molinario <andrea.molinario@lngs.infn.it>
     """
 
     version = 1
-    string = "nearest_muon_veto_trigger < -2000000 | nearest_muon_veto_trigger > 3000000"
+    string = "(nearest_muon_veto_trigger < -2e6 & nearest_muon_veto_trigger > -2e10) | 
+                (nearest_muon_veto_trigger > 3e6 & nearest_muon_veto_trigger < 2e10)"
 
 
 class KryptonMisIdS1(StringLichen):


### PR DESCRIPTION
Following the discussion at F2F meeting, we decided to cut events which are more than 20 s (in absolute value) far from their closest MV trigger. This will exclude periods in which the MV was not working.

https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:mv_cut_sr1#update_2017_12_7