### PR TITLE
Remove MV cut from calibration data

### DIFF
--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -37,7 +37,6 @@ class AllEnergy(ManyLichen):
             DAQVeto(),
             S1SingleScatter(),
             S2PatternLikelihood(),
-            MuonVeto(),
             KryptonMisIdS1(),
             Flash(),
             PosDiff()
@@ -87,7 +86,8 @@ class LowEnergyBackground(LowEnergyRn220):
 
         self.lichen_list += [
             PreS2Junk(),
-            S2Tails()  # Only for LowE background (#88)
+            S2Tails(),  # Only for LowE background (#88)
+            MuonVeto()
         ]
 
 


### PR DESCRIPTION
Discovered new MV cut checking if MV is online was killing most NG events and many SR0 AmBe events, probably because MV was off.

This PR removes the cut from all calibration data, applying only to background, and splits it into two lichens so it's easy to identify later which cut (online or coincidence) removes each event.

Events removed by coincidence could be used later for understanding TPC events coincident with MV.