### PR TITLE
Update on S1PatternLikelihood cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -482,9 +482,10 @@ class S1PatternLikelihood(StringLichen):
 
     Details of the likelihood and cut definitions can be seen in the following notes.
        SR0: xenon:xenon1t:analysis:summary_note:s1_pattern_likelihood_cut
-       SR1: xenon:xenon1t:kazama:s1_pattern_cut_sr1
+       SR1: xenon:xenon1t:kazama:s1_pattern_cut_sr1, 
+            xenon:xenon1t:kazama:s1_pattern_cut_sr1#update_2018_jan_4th
 
-    Requires PositionReconstruction minitrees.
+    Requires PositionReconstruction minitrees (hax#174).
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -484,13 +484,13 @@ class S1PatternLikelihood(StringLichen):
        SR0: xenon:xenon1t:analysis:summary_note:s1_pattern_likelihood_cut
        SR1: xenon:xenon1t:kazama:s1_pattern_cut_sr1
 
-    Requires Extended minitrees.
+    Requires PositionReconstruction minitrees.
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
 
-    version = 1
-    string = "s1_pattern_fit < -17.384885 + 24.894875*s1**0.5 + 2.794984*s1 -0.237268*s1**1.5 + 0.005549*s1**2.0"
-
+    version = 2
+    string = "s1_pattern_fit_hax < -23.288612 + 28.928316*s1**0.5 + 1.942163*s1 -0.173226*s1**1.5 + 0.003968*s1**2.0"
+    
 
 class S2AreaFractionTop(Lichen):
     """Cuts events with an unusual fraction of S2 on top array.

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -482,7 +482,7 @@ class S1PatternLikelihood(StringLichen):
 
     Details of the likelihood and cut definitions can be seen in the following notes.
        SR0: xenon:xenon1t:analysis:summary_note:s1_pattern_likelihood_cut
-       SR1: xenon:xenon1t:kazama:s1_pattern_cut_sr1, 
+       SR1: xenon:xenon1t:kazama:s1_pattern_cut_sr1,
             xenon:xenon1t:kazama:s1_pattern_cut_sr1#update_2018_jan_4th
 
     Requires PositionReconstruction minitrees (hax#174).

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -490,7 +490,7 @@ class S1PatternLikelihood(StringLichen):
 
     version = 2
     string = "s1_pattern_fit_hax < -23.288612 + 28.928316*s1**0.5 + 1.942163*s1 -0.173226*s1**1.5 + 0.003968*s1**2.0"
-    
+
 
 class S2AreaFractionTop(Lichen):
     """Cuts events with an unusual fraction of S2 on top array.


### PR DESCRIPTION
It was found that previous s1 pattern likelihood is calculated based on observed positions. Because expected PMT hit-patterns are calculated using true interact positions, thus s1 pattern likelihood should also be calculated using field-distortion-corrected positions.
In PositionReconstruction minitrees, there is a variable named "s1_pattern_fit_hax", and the cut is reoptimized based on this variable. Details can be seen in https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:kazama:s1_pattern_cut_sr1#update_2018_jan_4th