### PR TITLE
s1 width cut to remove AC candidates

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -846,10 +846,10 @@ class PosDiff(Lichen):
         df.loc[:, self.name()] = True
         mask = df.eval('s2 > 0')
         df.loc[mask, 'temp'] = 0.152 * np.sin((df['r_observed_nn'] + 4.10) / 7.99 * 2 * np.pi) \
-                            + 0.633 - 0.00768 * df['r_observed_nn']
+            + 0.633 - 0.00768 * df['r_observed_nn']
         corrected_distance = '(((x_observed_nn - x_observed_tpf) ** 2 + (y_observed_nn - y_observed_tpf) ** 2) \
                               - 2 * (r_observed_nn - r_observed_tpf) * temp + temp**2) ** 0.5'
-        df.loc[mask, self.name()] = df.eval('{cdist} < 3.215 * exp(- s2 / 155) + 1.24 * exp( - s2 / 842) + 1.16' \
-                                         .format(cdist = corrected_distance))
+        df.loc[mask, self.name()] = df.eval('{cdist} < 3.215 * exp(- s2 / 155) + 1.24 * exp( - s2 / 842) + 1.16'
+                                            .format(cdist=corrected_distance))
 
         return df

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -492,7 +492,7 @@ class S1PatternLikelihood(StringLichen):
     version = 1
     string = "s1_pattern_fit < -17.384885 + 24.894875*s1**0.5 + 2.794984*s1 -0.237268*s1**1.5 + 0.005549*s1**2.0"
 
-    
+
 class S1Width(StringLichen):
     """Reject accidendal coicidence events from lone s1 and lone s2.
     This cut is optimized to remove anomalous leakage (probably AC) candidates found in Rn220 SR1 data.

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -74,7 +74,8 @@ class LowEnergyRn220(AllEnergy):
         self.lichen_list += [
             S1PatternLikelihood(),
             S1MaxPMT(),
-            S1AreaFractionTop()
+            S1AreaFractionTop(),
+            S1Width()
         ]
 
 
@@ -490,6 +491,20 @@ class S1PatternLikelihood(StringLichen):
 
     version = 1
     string = "s1_pattern_fit < -17.384885 + 24.894875*s1**0.5 + 2.794984*s1 -0.237268*s1**1.5 + 0.005549*s1**2.0"
+
+    
+class S1Width(StringLichen):
+    """Reject accidendal coicidence events from lone s1 and lone s2.
+    This cut is optimized to remove anomalous leakage (probably AC) candidates found in Rn220 SR1 data.
+    Details of the cut definition and acceptance can be seen in the following note.
+    xenon:xenon1t:analysis:sciencerun1:anomalous_background#s1_width_cut_for_removing_remaining_ac_events
+
+    Requires Extended minitrees.
+    Contact: Shingo Kazama <kazama@physik.uzh.ch>
+    """
+
+    version = 0
+    string = "s1_range_90p_area < 450."
 
 
 class S2AreaFractionTop(Lichen):

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -70,7 +70,8 @@ class LowEnergyRn220(AllEnergy):
         self.lichen_list += [
             S1PatternLikelihood(),
             S1MaxPMT(),
-            S1AreaFractionTop()
+            S1AreaFractionTop(),
+            S1Width()
         ]
 
 
@@ -229,6 +230,8 @@ S1LowEnergyRange = sciencerun0.S1LowEnergyRange
 S1MaxPMT = sciencerun0.S1MaxPMT
 
 S1PatternLikelihood = sciencerun0.S1PatternLikelihood
+
+S1Width = sciencerun0.S1Width
 
 S2AreaFractionTop = sciencerun0.S2AreaFractionTop
 


### PR DESCRIPTION
S1s for accidental coincidence events are mainly originating from single electron reconstructed as s1 or accidental coincidence of PMT dark count (>3 PMT hits within 50 ns), therefore they could have relatively large s1 width compared to actual s1.
This proposed cut is just to remove events with very large s1 width, so the estimated acceptance is ~100%. 
With this cut, some anomalous leakage candidates found in Rn220 calibration data can be removed as shown in this note.
https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:anomalous_background#s1_width_cut_for_removing_remaining_ac_events