### PR TITLE
Cut on area fraction near Rn220 injection points

### DIFF
--- a/bin/laxer
+++ b/bin/laxer
@@ -59,7 +59,7 @@ def main():
     PAX_VERSION_POLICY = args.PAX_VERSION
     RUN_NUMBER = args.RUN_NUMBER
     MINITREE_NAMES = ['Fundamentals', 'Corrections', 'Basics', 'TotalProperties',
-                      'Extended', 'TailCut', 'Proximity']
+                      'Extended', 'TailCut', 'Proximity', 'PositionReconstruction']
     OUTPUT_PATH = args.OUTPUT_PATH
 
     # Harcode warning: This should be more flexible, allowing

--- a/bin/laxer
+++ b/bin/laxer
@@ -35,7 +35,7 @@ def main():
                         help='Run number to process (-1 for MC)')
 
     parser.add_argument('-s', '--sciencerun', dest='SCIENCERUN',
-                        action='store', required=True, type=int, choices=range(0,2),
+                        action='store', required=True, type=int, choices=range(0, 2),
                         help='lax science run cuts to use')
 
     parser.add_argument('-p', '--pax_version', dest='PAX_VERSION',
@@ -92,25 +92,23 @@ def main():
         MINITREE_NAMES.remove('TailCut')
         MINITREE_NAMES.remove('Proximity')
 
-        # Remove meaningless cuts (DAQVeto, S2Tails)
+        # Remove meaningless cuts for MC
         for cuts in LAX_LICHENS:
             if args.verbose:
-                print ("Pruning cuts for MC:", cuts)
+                print("Pruning cuts for MC:", cuts)
 
-            for idx, lichen in enumerate(cuts.lichen_list):
-                if lichen.name() == "CutDAQVeto" or lichen.name() == "CutS2Tails" or lichen.name() == "CutMuonVeto":
-                    if args.verbose:
-                        print ("Removing", cuts.lichen_list[idx].name())
-                    cuts.lichen_list.pop(idx)
-                    idx -= 1
+            cuts.lichen_list = [lichen for lichen in cuts.lichen_list
+                                if "DAQVeto" not in lichen.name() and
+                                   "S2Tails" not in lichen.name() and
+                                   "MuonVeto" not in lichen.name()]
 
             if args.verbose:
-                print (cuts.lichen_list, "\n")
+                print(cuts.lichen_list, "\n")
 
         TREENAME += 'mc'
 
         if OUTPUT_PATH is '':
-            OUTPUT_PATH = args.FILENAME+"_lax"
+            OUTPUT_PATH = args.FILENAME + "_lax"
 
     if OUTPUT_PATH is '':
         OUTPUT_PATH = "%d_lax" % RUN_NUMBER
@@ -121,7 +119,7 @@ def main():
     HAX_KWARGS = {'experiment': 'XENON1T',
                   'pax_version_policy': PAX_VERSION_POLICY,
                   'minitree_paths': ['.', args.MINITREE_PATH]
-                 }
+                  }
 
     # Be careful what you're doing here
     if args.RUN_NUMBER < 0:
@@ -131,17 +129,18 @@ def main():
 
     DF_ALL = hax.minitrees.load(RUN_NUMBER, MINITREE_NAMES)
 
-    print ("hax initialized with", HAX_KWARGS, "\nRUN_NUMBER = ", RUN_NUMBER,
-           "\nMINITREE_NAMES = ", MINITREE_NAMES)
+    print("hax initialized with", HAX_KWARGS, "\nRUN_NUMBER = ", RUN_NUMBER,
+          "\nMINITREE_NAMES = ", MINITREE_NAMES)
 
     for cuts in LAX_LICHENS:
 
         DF_ALL = cuts.process(DF_ALL)
 
-    OUTPUT_FILE = OUTPUT_PATH+'.root' 
+    OUTPUT_FILE = OUTPUT_PATH + '.root'
     DF_ALL.to_root(OUTPUT_FILE, TREENAME)
 
-    print ("Output file written to: ", OUTPUT_FILE)
+    print("Output file written to: ", OUTPUT_FILE)
+
 
 if __name__ == "__main__":
     main()

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -77,32 +77,45 @@ class LowEnergyRn220(AllEnergy):
             S1AreaFractionTop()
         ]
 
-
-class LowEnergyBackground(LowEnergyRn220):
-    """Select background events with cs1<200
-
-    This is the list that we'll use for the actual DM search. Additionally to the
-    LowEnergyRn220 list it contains the PreS2Junk
-    """
-
-    def __init__(self):
-        LowEnergyRn220.__init__(self)
-
+        # Add cuts specific to Rn220 only
         self.lichen_list += [
-            PreS2Junk(),
-            S2Tails(),  # Only for LowE background (#88)
-            MuonVeto()
+            S1AreaUpperInjectionFraction(),
+            S1AreaLowerInjectionFraction()
         ]
 
 
 class LowEnergyAmBe(LowEnergyRn220):
     """Select AmBe events with cs1<200 with appropriate cuts
 
-    It is the same as the LowEnergyRn220 cuts.
+    It is the same as the LowEnergyRn220 cuts, except injection-related cuts
     """
 
     def __init__(self):
         LowEnergyRn220.__init__(self)
+
+        # Remove cuts specific to Rn220
+        for idx, lichen in enumerate(self.lichen_list):
+            if "InjectionFraction" in lichen.name():
+                self.lichen_list.pop(idx)
+                idx -= 1
+
+
+class LowEnergyBackground(LowEnergyAmBe):
+    """Select background events with cs1<200
+
+    This is the list that we'll use for the actual DM search. Additionally to the
+    LowEnergyAmBe list it contains the PreS2Junk, S2Tails, and MuonVeto
+    """
+
+    def __init__(self):
+        LowEnergyAmBe.__init__(self)
+
+        # Add cuts specific to background only
+        self.lichen_list += [
+            PreS2Junk(),
+            S2Tails(),  # Only for LowE background (#88)
+            MuonVeto()
+        ]
 
 
 class DAQVeto(ManyLichen):
@@ -493,29 +506,29 @@ class S1PatternLikelihood(StringLichen):
 
 
 class S1AreaUpperInjectionFraction(StringLichen):
-  """Reject accidendal coicidence events happened near the upper Rn220 injection point (near PMT 131)
-    
+    """Reject accidendal coicidence events happened near the upper Rn220 injection point (near PMT 131)
+
     Details of the cut definition and acceptance can be seen in the following notes.
     xenon:xenon1t:analysis:sciencerun1:anomalous_background#signal_area_fraction_near_rn220_injection_points
-    
+
     Requires PositionReconstruction minitrees.
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
-    
+
     version = 0
     string = "s1_area_upper_injection_fraction < 0.0865 + 1.25/(s1**0.83367)"
 
 
 class S1AreaLowerInjectionFraction(StringLichen):
-  """Reject accidendal coicidence events happened near the lower Rn220 injection point (near PMT 243)
-    
+    """Reject accidendal coicidence events happened near the lower Rn220 injection point (near PMT 243)
+
     Details of the cut definition and acceptance can be seen in the following notes.
     xenon:xenon1t:analysis:sciencerun1:anomalous_background#signal_area_fraction_near_rn220_injection_points
-    
+
     Requires PositionReconstruction minitrees.
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
-    
+
     version = 0
     string = "s1_area_lower_injection_fraction < 0.0550 + 1.56/(s1**0.87000)"
 
@@ -859,10 +872,10 @@ class PosDiff(Lichen):
         df.loc[:, self.name()] = True
         mask = df.eval('s2 > 0')
         df.loc[mask, 'temp'] = 0.152 * np.sin((df['r_observed_nn'] + 4.10) / 7.99 * 2 * np.pi) \
-                            + 0.633 - 0.00768 * df['r_observed_nn']
+            + 0.633 - 0.00768 * df['r_observed_nn']
         corrected_distance = '(((x_observed_nn - x_observed_tpf) ** 2 + (y_observed_nn - y_observed_tpf) ** 2) \
                               - 2 * (r_observed_nn - r_observed_tpf) * temp + temp**2) ** 0.5'
-        df.loc[mask, self.name()] = df.eval('{cdist} < 3.215 * exp(- s2 / 155) + 1.24 * exp( - s2 / 842) + 1.16' \
-                                         .format(cdist = corrected_distance))
+        df.loc[mask, self.name()] = df.eval('{cdist} < 3.215 * exp(- s2 / 155) + 1.24 * exp( - s2 / 842) + 1.16'
+                                            .format(cdist=corrected_distance))
 
         return df

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -77,10 +77,28 @@ class LowEnergyRn220(AllEnergy):
             S1AreaFractionTop()
         ]
 
-        # Add cuts specific to Rn220 only
+        # Add injection-position cuts (not for AmBe)
         self.lichen_list += [
             S1AreaUpperInjectionFraction(),
             S1AreaLowerInjectionFraction()
+        ]
+
+
+class LowEnergyBackground(LowEnergyRn220):
+    """Select background events with cs1<200
+
+    This is the list that we'll use for the actual DM search. Additionally to the
+    LowEnergyAmBe list it contains the PreS2Junk, S2Tails, and MuonVeto
+    """
+
+    def __init__(self):
+        LowEnergyRn220.__init__(self)
+
+        # Add cuts specific to background only
+        self.lichen_list += [
+            PreS2Junk(),
+            S2Tails(),  # Only for LowE background (#88)
+            MuonVeto()
         ]
 
 
@@ -93,27 +111,9 @@ class LowEnergyAmBe(LowEnergyRn220):
     def __init__(self):
         LowEnergyRn220.__init__(self)
 
-        # Remove cuts specific to Rn220
+        # Remove cuts not applicable to AmBe
         self.lichen_list = [lichen for lichen in self.lichen_list
                             if "InjectionFraction" not in lichen.name()]
-
-
-class LowEnergyBackground(LowEnergyAmBe):
-    """Select background events with cs1<200
-
-    This is the list that we'll use for the actual DM search. Additionally to the
-    LowEnergyAmBe list it contains the PreS2Junk, S2Tails, and MuonVeto
-    """
-
-    def __init__(self):
-        LowEnergyAmBe.__init__(self)
-
-        # Add cuts specific to background only
-        self.lichen_list += [
-            PreS2Junk(),
-            S2Tails(),  # Only for LowE background (#88)
-            MuonVeto()
-        ]
 
 
 class DAQVeto(ManyLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -493,7 +493,7 @@ class S1PatternLikelihood(StringLichen):
 
 
 class S1AreaUpperInjectionFraction(StringLichen):
-    """Reject accidendal coicidence events happened near the upper Rn220 injection point (near PMT 131)
+  """Reject accidendal coicidence events happened near the upper Rn220 injection point (near PMT 131)
     
     Details of the cut definition and acceptance can be seen in the following notes.
     xenon:xenon1t:analysis:sciencerun1:anomalous_background#signal_area_fraction_near_rn220_injection_points
@@ -507,7 +507,7 @@ class S1AreaUpperInjectionFraction(StringLichen):
 
 
 class S1AreaLowerInjectionFraction(StringLichen):
-    """Reject accidendal coicidence events happened near the lower Rn220 injection point (near PMT 243)
+  """Reject accidendal coicidence events happened near the lower Rn220 injection point (near PMT 243)
     
     Details of the cut definition and acceptance can be seen in the following notes.
     xenon:xenon1t:analysis:sciencerun1:anomalous_background#signal_area_fraction_near_rn220_injection_points

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -94,10 +94,8 @@ class LowEnergyAmBe(LowEnergyRn220):
         LowEnergyRn220.__init__(self)
 
         # Remove cuts specific to Rn220
-        for idx, lichen in enumerate(self.lichen_list):
-            if "InjectionFraction" in lichen.name():
-                self.lichen_list.pop(idx)
-                idx -= 1
+        self.lichen_list = [lichen for lichen in self.lichen_list
+                            if "InjectionFraction" not in lichen.name()]
 
 
 class LowEnergyBackground(LowEnergyAmBe):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -492,6 +492,34 @@ class S1PatternLikelihood(StringLichen):
     string = "s1_pattern_fit < -17.384885 + 24.894875*s1**0.5 + 2.794984*s1 -0.237268*s1**1.5 + 0.005549*s1**2.0"
 
 
+class S1AreaUpperInjectionFraction(StringLichen):
+    """Reject accidendal coicidence events happened near the upper Rn220 injection point (near PMT 131)
+    
+    Details of the cut definition and acceptance can be seen in the following notes.
+    xenon:xenon1t:analysis:sciencerun1:anomalous_background#signal_area_fraction_near_rn220_injection_points
+    
+    Requires PositionReconstruction minitrees.
+    Contact: Shingo Kazama <kazama@physik.uzh.ch>
+    """
+
+    version = 0
+    string = "s1_area_upper_injection_fraction < 0.0865 + 1.25/(s1**0.83367)"
+
+
+class S1AreaLowerInjectionFraction(StringLichen):
+    """Reject accidendal coicidence events happened near the lower Rn220 injection point (near PMT 243)
+    
+    Details of the cut definition and acceptance can be seen in the following notes.
+    xenon:xenon1t:analysis:sciencerun1:anomalous_background#signal_area_fraction_near_rn220_injection_points
+    
+    Requires PositionReconstruction minitrees.
+    Contact: Shingo Kazama <kazama@physik.uzh.ch>
+    """
+
+    version = 0
+    string = "s1_area_lower_injection_fraction < 0.0550 + 1.56/(s1**0.87000)"
+
+
 class S2AreaFractionTop(Lichen):
     """Cuts events with an unusual fraction of S2 on top array.
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -501,7 +501,7 @@ class S1AreaUpperInjectionFraction(StringLichen):
     Requires PositionReconstruction minitrees.
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
-
+    
     version = 0
     string = "s1_area_upper_injection_fraction < 0.0865 + 1.25/(s1**0.83367)"
 
@@ -515,7 +515,7 @@ class S1AreaLowerInjectionFraction(StringLichen):
     Requires PositionReconstruction minitrees.
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
-
+    
     version = 0
     string = "s1_area_lower_injection_fraction < 0.0550 + 1.56/(s1**0.87000)"
 

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -90,10 +90,8 @@ class LowEnergyAmBe(LowEnergyRn220):
         LowEnergyRn220.__init__(self)
 
         # Remove cuts specific to Rn220
-        for idx, lichen in enumerate(self.lichen_list):
-            if "InjectionFraction" in lichen.name():
-                self.lichen_list.pop(idx)
-                idx -= 1
+        self.lichen_list = [lichen for lichen in self.lichen_list
+                            if "InjectionFraction" not in lichen.name()]
 
 
 class LowEnergyBackground(LowEnergyAmBe):
@@ -113,14 +111,14 @@ class LowEnergyBackground(LowEnergyAmBe):
         ]
 
 
-class LowEnergyNG(LowEnergyRn220):
+class LowEnergyNG(LowEnergyAmBe):
     """Select NG events with cs1<200 with appropriate cuts
 
-    It is the same as the LowEnergyRn220 cuts.
+    It is the same as the LowEnergyAmBe cuts.
     """
 
     def __init__(self):
-        LowEnergyRn220.__init__(self)
+        LowEnergyAmBe.__init__(self)
 
 
 DAQVeto = sciencerun0.DAQVeto

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -73,10 +73,27 @@ class LowEnergyRn220(AllEnergy):
             S1AreaFractionTop()
         ]
 
-        # Add cuts specific to Rn220 only
+        # Add injection-position cuts (not for AmBe/NG)
         self.lichen_list += [
             S1AreaUpperInjectionFraction(),
             S1AreaLowerInjectionFraction()
+        ]
+
+
+class LowEnergyBackground(LowEnergyRn220):
+    """Select background events with cs1<200
+
+    This is the list that we'll use for the actual DM search. In addition to the
+    LowEnergyRn220 list, it contains S2Tails and PreS2Junk.
+    """
+
+    def __init__(self):
+        LowEnergyRn220.__init__(self)
+
+        self.lichen_list += [
+            PreS2Junk(),
+            S2Tails(),  # Only for LowE background (#88)
+            MuonVeto()
         ]
 
 
@@ -89,26 +106,9 @@ class LowEnergyAmBe(LowEnergyRn220):
     def __init__(self):
         LowEnergyRn220.__init__(self)
 
-        # Remove cuts specific to Rn220
+        # Remove cuts not applicable to AmBe/NG
         self.lichen_list = [lichen for lichen in self.lichen_list
                             if "InjectionFraction" not in lichen.name()]
-
-
-class LowEnergyBackground(LowEnergyAmBe):
-    """Select background events with cs1<200
-
-    This is the list that we'll use for the actual DM search. In addition to the
-    LowEnergyRn220 list, it contains S2Tails and PreS2Junk.
-    """
-
-    def __init__(self):
-        LowEnergyAmBe.__init__(self)
-
-        self.lichen_list += [
-            PreS2Junk(),
-            S2Tails(),  # Only for LowE background (#88)
-            MuonVeto()
-        ]
 
 
 class LowEnergyNG(LowEnergyAmBe):

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -73,8 +73,30 @@ class LowEnergyRn220(AllEnergy):
             S1AreaFractionTop()
         ]
 
+        # Add cuts specific to Rn220 only
+        self.lichen_list += [
+            S1AreaUpperInjectionFraction(),
+            S1AreaLowerInjectionFraction()
+        ]
 
-class LowEnergyBackground(LowEnergyRn220):
+
+class LowEnergyAmBe(LowEnergyRn220):
+    """Select AmBe events with cs1<200 with appropriate cuts
+
+    It is the same as the LowEnergyRn220 cuts, except injection-related cuts
+    """
+
+    def __init__(self):
+        LowEnergyRn220.__init__(self)
+
+        # Remove cuts specific to Rn220
+        for idx, lichen in enumerate(self.lichen_list):
+            if "InjectionFraction" in lichen.name():
+                self.lichen_list.pop(idx)
+                idx -= 1
+
+
+class LowEnergyBackground(LowEnergyAmBe):
     """Select background events with cs1<200
 
     This is the list that we'll use for the actual DM search. In addition to the
@@ -82,23 +104,13 @@ class LowEnergyBackground(LowEnergyRn220):
     """
 
     def __init__(self):
-        LowEnergyRn220.__init__(self)
+        LowEnergyAmBe.__init__(self)
 
         self.lichen_list += [
             PreS2Junk(),
             S2Tails(),  # Only for LowE background (#88)
             MuonVeto()
         ]
-
-
-class LowEnergyAmBe(LowEnergyRn220):
-    """Select AmBe events with cs1<200 with appropriate cuts
-
-    It is the same as the LowEnergyRn220 cuts.
-    """
-
-    def __init__(self):
-        LowEnergyRn220.__init__(self)
 
 
 class LowEnergyNG(LowEnergyRn220):
@@ -283,3 +295,7 @@ KryptonMisIdS1 = sciencerun0.KryptonMisIdS1
 Flash = sciencerun0.Flash
 
 PosDiff = sciencerun0.PosDiff
+
+S1AreaUpperInjectionFraction = sciencerun0.S1AreaUpperInjectionFraction
+
+S1AreaLowerInjectionFraction = sciencerun0.S1AreaLowerInjectionFraction


### PR DESCRIPTION
As shown in this note (https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:anomalous_background#signal_area_fraction_near_rn220_injection_points), quite a lot of AC events are expected near Rn220 injection points (PMT 131 and 243). 
In order to remove possible AC events, cuts on signal area fraction near those regions are considered.
Cuts are designed to have N-1 acceptance of 99%, so these cuts are just killing some very bad events and should not affect majority of ER-band events.