### PR TITLE
Fix and tune S1 AFT cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -718,8 +718,8 @@ class S1AreaFractionTop(StringLichen):
     Contact: Darryl Masson, dmasson@purdue.edu
              Shingo Kazama, kazama@physik.uzh.ch
     '''
-    version = 3
-    string = "s1_area_fraction_top_probability_hax > 0.0005"
+    version = 4
+    string = "s1_area_fraction_top_probability_hax > 0.001"
 
 
 class PreS2Junk(StringLichen):


### PR DESCRIPTION
Modifications based on @skazama's [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:anomalous_background#s1_area_fraction_top_cut) following @darrylmasson's [bug fix](https://github.com/XENON1T/pax/pull/657):
* p-value now calculated in ```PositionReconstruction``` treemaker
  * Using 3D FDC corrected FANN position
  * ```binom_test``` bug fix in pax manually deployed to ```pax_v6.8.0``` environment so hax picks it up

* Tighten cut from 1e-4 to 5e-4
  * @skazama, how did you come up with this value? Can it be tightened further to 1e-3 so the leakage event in SR1 isn't straddling the line?

* Remove old backup calculation of p-value (we should never have to use this anymore)

@darrylmasson, I also updated your [summary note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:darryl:s1_aft_update#updatebug_fix_and_cut_tuning) to include this info. Please check for completeness and consider updating the whole note with new plots after bug fix before sending back to the reviewer (@Shintler).