### PR TITLE
Revert to SR0 version of S2 tail cut

### DIFF
--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -113,21 +113,7 @@ class LowEnergyNG(LowEnergyRn220):
 
 DAQVeto = sciencerun0.DAQVeto
 
-
-class S2Tails(Lichen):
-    """Check if event is in a tail of a previous S2
-    Requires S2Tail minitrees.
-    https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:analysis:subgroup:wimphysics:s2_tails_sr0 (SR0)
-    https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:analysis:subgroup:20170720_sr1_cut_s2_tail (SR1)
-    Contact: Daniel Coderre <daniel.coderre@physik.uni-freiburg.de>
-             Diego Ramírez <diego.ramirez@physik.uni-freiburg.de>
-    """
-    version = 1
-
-    def _process(self, df):
-        df.loc[:, self.name()] = (df['s2_over_tdiff'] < 0.025)
-        return df
-
+S2Tails = sciencerun0.S2Tails
 
 FiducialCylinder1T_TPF2dFDC = sciencerun0.FiducialCylinder1T_TPF2dFDC
 

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 from pax import units
 
-from lax.lichen import Lichen, ManyLichen, StringLichen
+from lax.lichen import ManyLichen, StringLichen
 from lax.lichens import sciencerun0
 from lax import __version__ as lax_version
 


### PR DESCRIPTION
The SR1 version of the S2 tail cut has an 8% acceptance loss (ca 2.5 weeks of removed data). Reverting to the old SR1 version puts us at 4% acceptance loss. 

https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:s2tails

I'll fiddle a bit more with the cut now but I think restoring to the SR0 value is justifiable (the value was pulled out of a hat, but at least now it's precedent) and reasonable if nothing smarter is immediately found.