### PR TITLE
Syntax corrected for MV cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -798,7 +798,7 @@ class MuonVeto(ManyLichen):
 
     Contact: Andrea Molinario <andrea.molinario@lngs.infn.it>
     """
-    version = 2
+    version = 3
 
     class MuonVetoCoincidence(StringLichen):
         """Checks the distance in time (ns) between a reference position inside the waveform

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -807,13 +807,13 @@ class MuonVeto(ManyLichen):
         with respect to the reference position.
         """
 
-        string = ("nearest_muon_veto_trigger < -2e6 | nearest_muon_veto_trigger > 3e6")
+        string = "nearest_muon_veto_trigger < -2e6 | nearest_muon_veto_trigger > 3e6"
 
     class MuonVetoOn(StringLichen):
         """Remove events when MV was not working (abs(nearest_muon_veto_trigger)>20 s).
         """
 
-        string = ("nearest_muon_veto_trigger > -2e10 & nearest_muon_veto_trigger < 2e10)")
+        string = "nearest_muon_veto_trigger > -2e10 & nearest_muon_veto_trigger < 2e10"
 
 
 class KryptonMisIdS1(StringLichen):


### PR DESCRIPTION
We found that the MV cut was not cutting any event. It looked like the syntax of the string for MV cut was not correct in sciencerun0.py. This has been fixed now.