### PR TITLE
Update on s1 width cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -512,8 +512,8 @@ class S1Width(StringLichen):
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
 
-    version = 0
-    string = "s1_range_90p_area < 450."
+    version = 1
+    string = "s1_range_90p_area < 251.528247 + 11.50*s1**1.171407*exp(-0.057395*s1)"
 
 
 class S1AreaUpperInjectionFraction(StringLichen):


### PR DESCRIPTION
After discussion on Monday, s1 width cut is re-designed to 99% quantile line. Cut line and acceptance for all the calibration data can be seen in this
[note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:anomalous_background#s1_width_cut_for_removing_remaining_ac_events)