### PR TITLE
Fixing a typo in S1AreaUpperInjectionFraction cut

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -526,8 +526,8 @@ class S1AreaUpperInjectionFraction(StringLichen):
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
 
-    version = 0
-    string = "s1_area_upper_injection_fraction < 0.0865 + 1.25/(s1**0.83367)"
+    version = 1
+    string = "s1_area_upper_injection_fraction < 0.0865 + 1.205/(s1**0.83367)"
 
 
 class S1AreaLowerInjectionFraction(StringLichen):


### PR DESCRIPTION
sorry but, I found a typo in S1AreaUpperInjectionFraction cut. The difference is quite small, so the effect to acceptance should be also small. In this [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:anomalous_background), new cut was already used.