### PR TITLE
Bug-fix for s1 pattern likelihood cuts

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -500,8 +500,7 @@ class S1PatternLikelihood(Lichen):
     version = 3
     def _process(self, df):
         s1t = df['s1']*df['s1_area_fraction_top']
-        s1b = df['s1']*(1.-df['s1_area_fraction_top'])
-      
+        s1b = df['s1']*(1.-df['s1_area_fraction_top'])      
         df.loc[:, self.name()] = ((df['s1_pattern_fit_hax']-df['s1_pattern_fit_bottom_hax']
                                    < 13.0 + 2.3*s1t**0.5 + 8.0*s1t - 1.0*s1t**1.5 + 0.04*s1t**2.0) &
                                   (df['s1_pattern_fit_bottom_hax']

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -504,7 +504,8 @@ class S1PatternLikelihood(ManyLichen):
                             self.S1BottomPatternLikelihood()]
 
     class S1TopPatternLikelihood(Lichen):
-
+        """S1PatternLikelihood cut based on the top PMT array
+        """
         def _process(self, df):
             s1t = df['s1'] * df['s1_area_fraction_top']
             df.loc[:, self.name()] = (df['s1_pattern_fit_hax'] - df['s1_pattern_fit_bottom_hax'] <
@@ -512,7 +513,8 @@ class S1PatternLikelihood(ManyLichen):
             return df
 
     class S1BottomPatternLikelihood(Lichen):
-
+        """S1PatternLikelihood cut based on the bottom PMT array
+        """
         def _process(self, df):
             s1b = df['s1'] * (1. - df['s1_area_fraction_top'])
             df.loc[:, self.name()] = (df['s1_pattern_fit_bottom_hax'] < - 10.5 + 21.9 * s1b**0.5 +

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -499,15 +499,14 @@ class S1PatternLikelihood(Lichen):
     """
     version = 3
     def _process(self, df):
+        s1t = df['s1']*df['s1_area_fraction_top']
+        s1b = df['s1']*(1.-df['s1_area_fraction_top'])
       
-      s1t = df['s1']*df['s1_area_fraction_top']
-      s1b = df['s1']*(1.-df['s1_area_fraction_top'])
-      
-      df.loc[:, self.name()] = ((df['s1_pattern_fit_hax']-df['s1_pattern_fit_bottom_hax']
-                                 < 13.0 + 2.3*s1t**0.5 + 8.0*s1t - 1.0*s1t**1.5 + 0.04*s1t**2.0) &
-                                (df['s1_pattern_fit_bottom_hax']
-                                 < -10.5 + 21.9*s1b**0.5 + 1.44*s1b - 0.21*s1b**1.5 + 0.0064*s1b**2.0))
-      return df
+        df.loc[:, self.name()] = ((df['s1_pattern_fit_hax']-df['s1_pattern_fit_bottom_hax']
+                                   < 13.0 + 2.3*s1t**0.5 + 8.0*s1t - 1.0*s1t**1.5 + 0.04*s1t**2.0) &
+                                  (df['s1_pattern_fit_bottom_hax']
+                                   < -10.5 + 21.9*s1b**0.5 + 1.44*s1b - 0.21*s1b**1.5 + 0.0064*s1b**2.0))
+        return df
 
 
 class S1Width(StringLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -498,13 +498,14 @@ class S1PatternLikelihood(Lichen):
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
     version = 3
+
     def _process(self, df):
-        s1t = df['s1']*df['s1_area_fraction_top']
-        s1b = df['s1']*(1.-df['s1_area_fraction_top'])      
-        df.loc[:, self.name()] = ((df['s1_pattern_fit_hax']-df['s1_pattern_fit_bottom_hax']
-                                   < 13.0 + 2.3*s1t**0.5 + 8.0*s1t - 1.0*s1t**1.5 + 0.04*s1t**2.0) &
-                                  (df['s1_pattern_fit_bottom_hax']
-                                   < -10.5 + 21.9*s1b**0.5 + 1.44*s1b - 0.21*s1b**1.5 + 0.0064*s1b**2.0))
+        s1t = df['s1'] * df['s1_area_fraction_top']
+        s1b = df['s1'] * (1. - df['s1_area_fraction_top'])
+        df.loc[:, self.name()] = ((df['s1_pattern_fit_hax'] - df['s1_pattern_fit_bottom_hax'] <
+                                   13.0 + 2.3 * s1t**0.5 + 8.0 * s1t - 1.0 * s1t**1.5 + 0.04 * s1t**2.0) &
+                                  (df['s1_pattern_fit_bottom_hax'] < - 10.5 + 21.9 * s1b**0.5 +
+                                   1.44 * s1b - 0.21 * s1b**1.5 + 0.0064 * s1b**2.0))
         return df
 
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -486,7 +486,7 @@ class S1MaxPMT(StringLichen):
     string = "s1_largest_hit_area < 0.052 * s1 + 4.15"
 
 
-class S1PatternLikelihood(Lichen):
+class S1PatternLikelihood(ManyLichen):
     """Reject accidendal coicident events from lone s1 and lone s2.
 
     Details of the likelihood and cut definitions can be seen in the following notes.
@@ -499,14 +499,25 @@ class S1PatternLikelihood(Lichen):
     """
     version = 3
 
-    def _process(self, df):
-        s1t = df['s1'] * df['s1_area_fraction_top']
-        s1b = df['s1'] * (1. - df['s1_area_fraction_top'])
-        df.loc[:, self.name()] = ((df['s1_pattern_fit_hax'] - df['s1_pattern_fit_bottom_hax'] <
-                                   13.0 + 2.3 * s1t**0.5 + 8.0 * s1t - 1.0 * s1t**1.5 + 0.04 * s1t**2.0) &
-                                  (df['s1_pattern_fit_bottom_hax'] < - 10.5 + 21.9 * s1b**0.5 +
-                                   1.44 * s1b - 0.21 * s1b**1.5 + 0.0064 * s1b**2.0))
-        return df
+    def __init__(self):
+        self.lichen_list = [self.S1TopPatternLikelihood(),
+                            self.S1BottomPatternLikelihood()]
+
+    class S1TopPatternLikelihood(Lichen):
+
+        def _process(self, df):
+            s1t = df['s1'] * df['s1_area_fraction_top']
+            df.loc[:, self.name()] = (df['s1_pattern_fit_hax'] - df['s1_pattern_fit_bottom_hax'] <
+                                      13.0 + 2.3 * s1t**0.5 + 8.0 * s1t - 1.0 * s1t**1.5 + 0.04 * s1t**2.0)
+            return df
+
+    class S1BottomPatternLikelihood(Lichen):
+
+        def _process(self, df):
+            s1b = df['s1'] * (1. - df['s1_area_fraction_top'])
+            df.loc[:, self.name()] = (df['s1_pattern_fit_bottom_hax'] < - 10.5 + 21.9 * s1b**0.5 +
+                                      1.44 * s1b - 0.21 * s1b**1.5 + 0.0064 * s1b**2.0)
+            return df
 
 
 class S1Width(StringLichen):

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -486,20 +486,28 @@ class S1MaxPMT(StringLichen):
     string = "s1_largest_hit_area < 0.052 * s1 + 4.15"
 
 
-class S1PatternLikelihood(StringLichen):
+class S1PatternLikelihood(Lichen):
     """Reject accidendal coicident events from lone s1 and lone s2.
 
     Details of the likelihood and cut definitions can be seen in the following notes.
        SR0: xenon:xenon1t:analysis:summary_note:s1_pattern_likelihood_cut
        SR1: xenon:xenon1t:kazama:s1_pattern_cut_sr1,
-            xenon:xenon1t:kazama:s1_pattern_cut_sr1#update_2018_jan_4th
+            xenon:xenon1t:kazama:s1_pattern_cut_sr1#update_2018_jan_24th
 
     Requires PositionReconstruction minitrees (hax#174).
     Contact: Shingo Kazama <kazama@physik.uzh.ch>
     """
-
-    version = 2
-    string = "s1_pattern_fit_hax < -23.288612 + 28.928316*s1**0.5 + 1.942163*s1 -0.173226*s1**1.5 + 0.003968*s1**2.0"
+    version = 3
+    def _process(self, df):
+      
+      s1t = df['s1']*df['s1_area_fraction_top']
+      s1b = df['s1']*(1.-df['s1_area_fraction_top'])
+      
+      df.loc[:, self.name()] = ((df['s1_pattern_fit_hax']-df['s1_pattern_fit_bottom_hax']
+                                 < 13.0 + 2.3*s1t**0.5 + 8.0*s1t - 1.0*s1t**1.5 + 0.04*s1t**2.0) &
+                                (df['s1_pattern_fit_bottom_hax']
+                                 < -10.5 + 21.9*s1b**0.5 + 1.44*s1b - 0.21*s1b**1.5 + 0.0064*s1b**2.0))
+      return df
 
 
 class S1Width(StringLichen):


### PR DESCRIPTION
Dan and Jelle found that dead PMTs are included in the calculation of expected hit-patterns (See [this link](https://github.com/XENON1T/pax/pull/663)), and then cuts are optimized again with bug-fix.

From this version, we decided to use s1 pattern likelihood cut for top and bottom PMT arrays separately as done in XENON100. This is because if we use combined one, information can be smeared due to many PMTs, and the combined variable might be no longer sensitive to rejecting bad events like AC. 

Optimization of cuts are done in the same way as done in the combined variable (99% quantile for Rn220 SR1 data), but done as a function of s1(bottom) and s1(top), respectively.

Details can be seen in this [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:kazama:s1_pattern_cut_sr1#update_2018_jan_24th)