### PR TITLE
Add Z-optimized FV and swap in cut list

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -263,8 +263,8 @@ class FiducialZOptimized(StringLichen):
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume
     """
     version = 0
-    string = "(-95 < z_3d_nn) & ( ((r_3d_nn <= 35.22) & (z_3d_nn < -7)) | \
-              ((r_3d_nn > 35.22) & (z_3d_nn < 27.2929 - 0.0276385*r_3d_nn*r_3d_nn)) )"
+    string = "(-95 < z_3d_nn) & (z_3d_nn < -7) & \
+              (z_3d_nn < 27.2929 - 0.0276385*r_3d_nn*r_3d_nn)"
 
 
 FV_CONFIGS = [

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -31,7 +31,7 @@ class AllEnergy(ManyLichen):
 
     def __init__(self):
         self.lichen_list = [
-            FiducialCylinder1p3T(),
+            FiducialZOptimized(),
             InteractionExists(),
             S2Threshold(),
             InteractionPeaksBiggest(),
@@ -238,11 +238,7 @@ class FiducialCylinder1T(StringLichen):
 
     """
     version = 5
-    string = "(-92.9 < z_3d_nn) & (z_3d_nn < -9) & (sqrt(x_3d_nn*x_3d_nn + y_3d_nn*y_3d_nn) < 36.94)"
-
-    def pre(self, df):
-        df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn'] * df['x_3d_nn'] + df['y_3d_nn'] * df['y_3d_nn'])
-        return df
+    string = "(-92.9 < z_3d_nn) & (z_3d_nn < -9) & (r_3d_nn < 36.94)"
 
 
 class FiducialCylinder1p3T(StringLichen):
@@ -254,11 +250,21 @@ class FiducialCylinder1p3T(StringLichen):
 
     """
     version = 0
-    string = "(-92.9 < z_3d_nn) & (z_3d_nn < -9) & (sqrt(x_3d_nn*x_3d_nn + y_3d_nn*y_3d_nn) < 41.26)"
+    string = "(-92.9 < z_3d_nn) & (z_3d_nn < -9) & (r_3d_nn < 41.26)"
 
-    def pre(self, df):
-        df.loc[:, 'r_3d_nn'] = np.sqrt(df['x_3d_nn'] * df['x_3d_nn'] + df['y_3d_nn'] * df['y_3d_nn'])
-        return df
+
+class FiducialZOptimized(StringLichen):
+    """Z-optimized FV cut based on keeping expected rate variation within 10% threshold within each
+    R slice, i.e. ~uniform in Z accounting for all backgrounds models.
+
+    This first version is a bit rough and may be improved by understanding the underlying BG KDE
+    and errors better.
+
+    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume
+    """
+    version = 0
+    string = "(r_3d_nn < 44) & (-95 < z_3d_nn) & ( ((r_3d_nn <= 35.22) & (z_3d_nn < -7)) | \
+              ((r_3d_nn > 35.22) & (z_3d_nn < 27.2929 - 0.0276385*r_3d_nn*r_3d_nn)) )"
 
 
 FV_CONFIGS = [
@@ -931,7 +937,8 @@ class PosDiff(Lichen):
 
     def _process(self, df):
         df.loc[:, self.name()] = (np.sqrt((df['x_observed_nn'] - df['x_observed_tpf'])**2 +
-                                          (df['y_observed_nn'] - df['y_observed_tpf'])**2) < 2429.322*np.exp(-np.log10(df.s2)/0.362) + 1.587)
+                                          (df['y_observed_nn'] - df['y_observed_tpf'])**2) <
+                                  2429.322 * np.exp(-np.log10(df.s2) / 0.362) + 1.587)
         return df
 
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -263,7 +263,7 @@ class FiducialZOptimized(StringLichen):
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume
     """
     version = 0
-    string = "(r_3d_nn < 44) & (-95 < z_3d_nn) & ( ((r_3d_nn <= 35.22) & (z_3d_nn < -7)) | \
+    string = "(-95 < z_3d_nn) & ( ((r_3d_nn <= 35.22) & (z_3d_nn < -7)) | \
               ((r_3d_nn > 35.22) & (z_3d_nn < 27.2929 - 0.0276385*r_3d_nn*r_3d_nn)) )"
 
 

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -27,7 +27,7 @@ class AllEnergy(ManyLichen):
 
     def __init__(self):
         self.lichen_list = [
-            FiducialCylinder1p3T(),
+            FiducialZOptimized(),
             InteractionExists(),
             S2Threshold(),
             InteractionPeaksBiggest(),
@@ -132,6 +132,8 @@ FiducialCylinder1T_TPF2dFDC = sciencerun0.FiducialCylinder1T_TPF2dFDC
 FiducialCylinder1T = sciencerun0.FiducialCylinder1T
 
 FiducialCylinder1p3T = sciencerun0.FiducialCylinder1p3T
+
+FiducialZOptimized = sciencerun0.FiducialZOptimized
 
 FV_CONFIGS = [
     # Mass (kg), (z0, vz, p, vr2)


### PR DESCRIPTION
New fiducial volume cut based on optimizing Z in R slices.

- Bottom ```-95 cm``` limited by near-cathode events (@jhowl01)
- Top-center ```7 cm``` limited by gas events (@adambrown1, @skazama: Please double check with maximum stats and SR0 in your [S2 AFT note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:adam:s2aft:sr1_cs2_cut))
- Top-edge  ```Z < 27.2929 - 0.0276385*R^2``` based on expected background rate from all models, optimized for ~uniform event rate in Z.

Details in [this note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume) by @MAVJ and @hasterok.

New line overlaid with previous 1T and 1.3T cylinders below (note only BG histogram, so e.g. surface contribution in top right not shown):

SR0:
https://xe1t-wiki.lngs.infn.it/lib/exe/fetch.php?cache=&media=undefined:36402014-73ae4ea0-15a9-11e8-8644-815a8542c456.png

SR1:
https://xe1t-wiki.lngs.infn.it/lib/exe/fetch.php?cache=&media=36402015-73bb1842-15a9-11e8-9bf5-e7384eae28e3.png