### PR TITLE
Fix bug in FV z-optimization analysis

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -264,7 +264,8 @@ class FiducialZOptimized(StringLichen):
     """
     version = 1
     string = "(-95 < z_3d_nn) & (z_3d_nn < -8) & \
-              (z_3d_nn < 6.1863 - 0.0154508*r_3d_nn*r_3d_nn)"
+              (z_3d_nn < 6.1863 - 0.0154508*r_3d_nn*r_3d_nn) & \
+              (z_3d_nn > -157.727 + 0.0407326*r_3d_nn*r_3d_nn)"
 
 
 FV_CONFIGS = [

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -260,12 +260,12 @@ class FiducialZOptimized(StringLichen):
     This first version is a bit rough and may be improved by understanding the underlying BG KDE
     and errors better.
 
-    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume
+    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume_v2
     """
     version = 1
     string = "(-95 < z_3d_nn) & (z_3d_nn < -8) & (r_3d_nn < 42.8387) & \
-              (z_3d_nn < 6.1863 - 0.0154508*r_3d_nn*r_3d_nn) & \
-              (z_3d_nn > -157.727 + 0.0407326*r_3d_nn*r_3d_nn)"
+              (z_3d_nn < 5.71966 - 0.0149755*r_3d_nn*r_3d_nn) & \
+              (z_3d_nn > -157.587 + 0.0405219*r_3d_nn*r_3d_nn)"
 
 
 FV_CONFIGS = [

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -263,7 +263,7 @@ class FiducialZOptimized(StringLichen):
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume
     """
     version = 1
-    string = "(-95 < z_3d_nn) & (z_3d_nn < -8) & \
+    string = "(-95 < z_3d_nn) & (z_3d_nn < -8) & (r_3d_nn < 42.8387) & \
               (z_3d_nn < 6.1863 - 0.0154508*r_3d_nn*r_3d_nn) & \
               (z_3d_nn > -157.727 + 0.0407326*r_3d_nn*r_3d_nn)"
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -262,9 +262,9 @@ class FiducialZOptimized(StringLichen):
 
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume
     """
-    version = 0
-    string = "(-95 < z_3d_nn) & (z_3d_nn < -7) & \
-              (z_3d_nn < 27.2929 - 0.0276385*r_3d_nn*r_3d_nn)"
+    version = 1
+    string = "(-95 < z_3d_nn) & (z_3d_nn < -8) & \
+              (z_3d_nn < 6.1863 - 0.0154508*r_3d_nn*r_3d_nn)"
 
 
 FV_CONFIGS = [


### PR DESCRIPTION
Re-optimize z-cut based on [bug fixed FV analysis](https://github.com/XENON1T/SR1Results/commit/d6cad5cf487204e675be5183bb7b062832aaf64d) (details below) and tighten z cut to ```-8 cm``` based on appearance of [leakage gas event in SR1 BG data](https://files.gitter.im/XENON1T/wimphysics/ctfy/014686_006430_join.png).

After review by @lgrandi, I think I may have found a bug where the ER KDE matrix was transposed when it shouldn't be. Now if we look at "er_kde" in the following figure (black line old cut), it seems to make more sense with the population extending across the top instead of down the side (which is not yet the TPC edge) and the bulge transposed now to the bottom-right corresponding to the other corner with large expected materials contribution:
https://xe1t-wiki.lngs.infn.it/lib/exe/fetch.php?cache=&media=36637720-844071d4-19b0-11e8-99b1-d4bdf0df9e88.png

Re-running the notebook and fit results in the following line:

[SR0](https://xe1t-wiki.lngs.infn.it/lib/exe/fetch.php?cache=&media=36637730-d862d266-19b0-11e8-8737-42f6a13e619a.png)        |  [SR1](https://xe1t-wiki.lngs.infn.it/lib/exe/fetch.php?cache=&media=36637731-dab588ce-19b0-11e8-9a09-6824a0179aec.png)


The new cut is significantly shallower and follows the background shape much better.

@feigaodm @mcfatelin If this is approved, please add to stack prior to next template regeneration.