### PR TITLE
Update FV cut with fixed ER scaling and smoothing

### DIFF
--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -264,7 +264,7 @@ class FiducialZOptimized(StringLichen):
     """
     version = 4
     string = "(-94 < z_3d_nn) & (z_3d_nn < -8) & (r_3d_nn < 42.8387) & \
-              (z_3d_nn < -4.20851 - 0.00778878*r_3d_nn*r_3d_nn) & \
+              (z_3d_nn < -2.63725 - 0.00946597*r_3d_nn*r_3d_nn) & \
               (z_3d_nn > -158.173 + 0.0456094*r_3d_nn*r_3d_nn)"
 
 

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -262,7 +262,7 @@ class FiducialZOptimized(StringLichen):
 
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume_v4
     """
-    version = 1
+    version = 4
     string = "(-94 < z_3d_nn) & (z_3d_nn < -8) & (r_3d_nn < 42.8387) & \
               (z_3d_nn < -4.20851 - 0.00778878*r_3d_nn*r_3d_nn) & \
               (z_3d_nn > -158.173 + 0.0456094*r_3d_nn*r_3d_nn)"

--- a/lax/lichens/sciencerun0.py
+++ b/lax/lichens/sciencerun0.py
@@ -260,12 +260,12 @@ class FiducialZOptimized(StringLichen):
     This first version is a bit rough and may be improved by understanding the underlying BG KDE
     and errors better.
 
-    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume_v2
+    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume_v4
     """
     version = 1
-    string = "(-95 < z_3d_nn) & (z_3d_nn < -8) & (r_3d_nn < 42.8387) & \
-              (z_3d_nn < 5.71966 - 0.0149755*r_3d_nn*r_3d_nn) & \
-              (z_3d_nn > -157.587 + 0.0405219*r_3d_nn*r_3d_nn)"
+    string = "(-94 < z_3d_nn) & (z_3d_nn < -8) & (r_3d_nn < 42.8387) & \
+              (z_3d_nn < -4.20851 - 0.00778878*r_3d_nn*r_3d_nn) & \
+              (z_3d_nn > -158.173 + 0.0456094*r_3d_nn*r_3d_nn)"
 
 
 FV_CONFIGS = [


### PR DESCRIPTION
Following comments from telecon today:

https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun1:summary_fiducial_volume_v4

I don't plan on fine-tuning any further.

(Based on https://github.com/XENON1T/SR1Results/commit/e813026db07c886ce145ddd63d3b8eab585021fc)