### PR TITLE
Added S1SingleScatterCut for SR2 with coincidence requirement >= 3 fo…

### DIFF
--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -250,7 +250,7 @@ class S1SingleScatter(Lichen):
     """
     
     version = 5
-    s2width = sciencerun1.S2Width
+    s2width = S2Width
     alt_s1_coincidence_threshold = 3
     
     def _process(self, df):

--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -229,7 +229,49 @@ class S2SingleScatter(Lichen):
 
 # S1 single scatter
 # Contact: Joran
-S1SingleScatter = sr1.S1SingleScatter
+class S1SingleScatter(Lichen):
+    """Requires only one valid interaction between the largest S2, and any S1 recorded before it.
+
+    The S1 cut checks that any possible secondary S1s recorded in a waveform, could not have also
+    produced a valid interaction with the primary S2. To check whether an interaction between the
+    second largest S1 and the largest S2 is valid, we use the S2Width cut. If the event would pass
+    the S2Width cut, a valid second interaction exists, and we may have mis-identified which S1 to
+    pair with the primary S2. Therefore we cut this event. If it fails the S2Width cut the event is
+    not removed.
+    
+    Requires Extended minitrees. 
+
+    The cut is investigated for SR2 here:
+    https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun2:s1singlescattercut
+
+    It should be applicable to data regardless whether it is ER or NR.
+    Contacts: Jacques Pienaar, <jpienaar@uchicago.edu>
+    (for SR2) Joran Angevaare, <j.angevaare@nikhef.nl>  
+    """
+    
+    version = 5
+    s2width = sciencerun1.S2Width
+    alt_s1_coincidence_threshold = 3
+    
+    def _process(self, df):
+        df.loc[:, self.name()] = True  # Default is True
+        mask = (df.alt_s1_interaction_drift_time > self.s2width.DriftTimeFromGate) & (
+                df.alt_s1_tight_coincidence >= self.alt_s1_coincidence_threshold)      
+    
+        # S2 width cut for alternate S1 - main S2 interaction
+        alt_n_electron = np.clip(df.loc[mask, 's2'], 0, 5000) / self.s2width.scg
+        
+        alt_rel_width = np.square(df.loc[mask,
+                's2_range_50p_area'] / self.s2width.SigmaToR50) - np.square(self.s2width.scw)
+        alt_rel_width /= np.square(self.s2width.s2_width_model(self.s2width,
+                df.loc[mask, 'alt_s1_interaction_drift_time']))
+
+        alt_interaction_passes = chi2.logpdf(
+                alt_rel_width * (alt_n_electron - 1), alt_n_electron) > - 20
+
+        df.loc[mask, (self.name())] = True ^ alt_interaction_passes
+
+        return df
 
 
 ##


### PR DESCRIPTION
As summarized here https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:analysis:sciencerun2:s1singlescattercut, the changes in the S1 Single scatter cut are aimed at requiring that the alternate S1 (whereon an event could be cut) should be detected in at least three PMTs. That is, prevent the cut from cutting on events where an alternate S1 is detected with a ```tight_coincidence == 2``` . I will wait with merging this pull request until Evan has given the green light that he has reprocessed the Extended minitrees (since the property has been added to this minitree earlier today with this pull request: https://github.com/XENON1T/hax/pull/253). 