### PR TITLE
Remove S2SingleScatterSimple

### DIFF
--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -57,10 +57,6 @@ class LowEnergyRn220(AllEnergy):
             if lichen.name() == "CutInteractionExists":
                 self.lichen_list[idx] = S1LowEnergyRange()
 
-            # Use a simpler single scatter cut for LowE
-            if lichen.name() == "CutS2SingleScatter":
-                self.lichen_list[idx] = S2SingleScatterSimple()
-
         # Add additional LowE cuts (that may not be tuned at HighE yet)
         self.lichen_list += [
             S1PatternLikelihood(),


### PR DESCRIPTION
In SR1, the `S2SingleScatter` cut was replaced by a simpler version, `S2SingleScatterSimple`, for low-energy analyses. In #160 this was removed for SR2, but  `LowEnergyRn220` lichen collection still referenced it, causing it to stop working.

This removes the S2SingleScatterSimple reference, using Tianyu's preliminary S2SingleScatter cut for all energies in SR2. Tianyu, could you confirm this is OK?

Thanks to @lmanenti for spotting the problem!
