### PR TITLE
Missing import of scipy.stats.chi2

### DIFF
--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -8,6 +8,7 @@ from lax.lichens import sciencerun1 as sr1
 from lax.lichens import postsr1
 DATA_DIR = sr1.DATA_DIR
 
+from scipy.stats import chi2
 
 ##
 # Combination cut packages


### PR DESCRIPTION
The S1SingleScatter cut uses the scipy.stats.chi2 module. In order to use this cut with hax.cuts.apply_lichen this package has to be imported first.