### PR TITLE
Update to PosDiff cut

### DIFF
--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -146,13 +146,15 @@ S2Width = sr1.S2Width
 
 # Position reconstruction discrepancy cut
 # Contact: Ricardo
+
+class PosDiff(Lichen):
 """
-Note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:peres:analysis:sr2:cutposdiff_tf
+Note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:peres:analysis:sr2:cutposdiff_set19
 Thihs is an updated version of the PosDiff cut tuned for Science Run 2. 
 It removes weirdly reconstructed events based on the difference between NN_tf and tpf algorithm reconstruction.
 Contact: Ricardo Peres <rperes@physik.uzh.ch>
-version = 5
-
+version = 5.1
+"""
 def _process(self,df):
     df.loc[:,self.name()] = (np.sqrt((df['x_observed_nn_tf'] - df['x_observed_tpf'])**2 +
                                      (df['y_observed_nn_tf'] - df['y_observed_tpf'])**2)) < 

--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -145,9 +145,20 @@ S2Tails = sr0.S2Tails
 S2Width = sr1.S2Width
 
 # Position reconstruction discrepancy cut
-# Contact: UNKNOWN!!
-PosDiff = sr0.PosDiff
+# Contact: Ricardo
+"""
+Note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:peres:analysis:sr2:cutposdiff_tf
+Thihs is an updated version of the PosDiff cut tuned for Science Run 2. 
+It removes weirdly reconstructed events based on the difference between NN_tf and tpf algorithm reconstruction.
+Contact: Ricardo Peres <rperes@physik.uzh.ch>
+version = 5
 
+def _process(self,df):
+    df.loc[:,self.name()] = (np.sqrt((df['x_observed_nn_tf'] - df['x_observed_tpf'])**2 +
+                                     (df['y_observed_nn_tf'] - df['y_observed_tpf'])**2)) < 
+                             (90555.9100 * np.exp(-np.log10(df.s2)/0.221584) + 3.435491)
+    return df
+    
 # S2 AFT
 # Contact: Giovanni, Dominick
 class CS2AreaFractionTopExtended(StringLichen):

--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -156,7 +156,7 @@ version = 5
 def _process(self,df):
     df.loc[:,self.name()] = (np.sqrt((df['x_observed_nn_tf'] - df['x_observed_tpf'])**2 +
                                      (df['y_observed_nn_tf'] - df['y_observed_tpf'])**2)) < 
-                             (90555.9100 * np.exp(-np.log10(df.s2)/0.221584) + 3.435491)
+                             (3574.38766518 * np.exp(-np.log10(df.s2)/0.342140864302) + 1.43838876151)
     return df
     
 # S2 AFT


### PR DESCRIPTION
An updated version of the PosDiff cut is proposed for SR2 data, based on the results presented in the following note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:peres:analysis:sr2:cutposdiff_tf.