### PR TITLE
Kr83mcut

### DIFF
--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -143,33 +143,3 @@ class CS2AreaFractionTopExtendedOldDesat(StringLichen):
         return df
 
 
-class MisIdS1SingleScatter(Lichen):
-    """Cut to target the shoulder on Kr83m data due to mis-identified krypton events.
-
-    This cut is defined in the space of cs1 and largest_s2_before_main_s2_area.
-    It's possible for one of the conversion electrons of the Kr83m decay to be mis-classified as an S2, 
-    leading to an S2 that occurs in time before the main S2 that is larger than typical single-electrons. 
-    Requires Extended minitrees.
-
-    Note: xenon:shockley:misids1singlescatter
-    Contact: Evan Shockley <ershockley@uchicago.edu>
-    """
-
-    version = 1.1
-    
-    pars = [60, 1.04, 4]  # from a fit to target only mis-Id Kr83m events
-    s1_thresh = 155  # cs1 PE. Up to this value the cut will be a straight line
-    cutval = 125 # straight line part of the cut
-    min_s1 = 25 # smallest S1 to consider cutting
-    
-    
-    def _cutline(self, x):
-        return self.pars[0] + (self.pars[1] / 1e6) * (x - 220) ** self.pars[2]
-    
-    def cutline(self, x):
-        return np.nan_to_num(self.cutval * (x < self.s1_thresh)) + np.nan_to_num((x >= self.s1_thresh) * self._cutline(x))
-    
-    def _process(self, df):
-        df.loc[:, self.name()] = (np.nan_to_num(df.largest_s2_before_main_s2_area) < self.cutline(df.cs1)) | \
-                                 (df.cs1 < self.min_s1)
-        return df

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -294,3 +294,5 @@ S1AreaUpperInjectionFraction = sciencerun0.S1AreaUpperInjectionFraction
 S1AreaLowerInjectionFraction = sciencerun0.S1AreaLowerInjectionFraction
 
 SingleElectronS2s = sciencerun0.SingleElectronS2s
+
+MisIdS1SingleScatter = sciencerun0.MisIdS1SingleScatter

--- a/lax/lichens/sciencerun1.py
+++ b/lax/lichens/sciencerun1.py
@@ -283,8 +283,6 @@ S1AreaFractionTop = sciencerun0.S1AreaFractionTop
 
 PreS2Junk = sciencerun0.PreS2Junk
 
-KryptonMisIdS1 = sciencerun0.KryptonMisIdS1
-
 Flash = sciencerun0.Flash
 
 PosDiff = sciencerun0.PosDiff
@@ -296,3 +294,5 @@ S1AreaLowerInjectionFraction = sciencerun0.S1AreaLowerInjectionFraction
 SingleElectronS2s = sciencerun0.SingleElectronS2s
 
 MisIdS1SingleScatter = sciencerun0.MisIdS1SingleScatter
+
+KryptonMisIdS1 = MisIdS1SingleScatter

--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -240,6 +240,7 @@ S1Width = sr0.S1Width
 
 # KryptonMisIdS1
 # Contact: Evan
+MisIdS1SingleScatter = sr0.MisIdS1SingleScatter
 KryptonMisIdS1 = sr0.KryptonMisIdS1
 
 # Remove S1s that are actually misidentified single electrons

--- a/lax/lichens/sciencerun2.py
+++ b/lax/lichens/sciencerun2.py
@@ -241,7 +241,7 @@ S1Width = sr0.S1Width
 # KryptonMisIdS1
 # Contact: Evan
 MisIdS1SingleScatter = sr0.MisIdS1SingleScatter
-KryptonMisIdS1 = sr0.KryptonMisIdS1
+KryptonMisIdS1 = MisIdS1SingleScatter
 
 # Remove S1s that are actually misidentified single electrons
 # Contact: Fei


### PR DESCRIPTION
This PR updates the MisIdS1SingleScatter cut, specifically for SR2 but also for SR1. 

I'm not sure what the best way to organize this is so if anyone thinks we should not add this cut to e.g. `sciencerun0.py` or `sciencerun1.py` please let me know. 

The note for the update can be found [here](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:shockley:lower:misids1singlescatter:sr2_misid). The cut is improved for both SR1 and SR2, where pax v6.10.1 data was used.  

I also compared the cut with the similar KryptonMisIdS1, where I found that the latter removes a subset of those removed by MisIdS1SingleScatter, but doesn't remove all the events that it should. I think we should merge these two cuts, but also wanted to keep some type of backwards compatibility, so I just set the cuts equal in the sciencerun1 and sciencerun2 files. I left sciencerun0.py in case anyone wants to use the old cut. 

Finally, this PR removes the MisIdS1SingleScatter cut previously defined in `postsr1.py`. Again, please let me know if a different organization is preferred.

