### PR TITLE
Update postsr1.py

### DIFF
--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -343,3 +343,42 @@ class S2Width_HE(Lichen):
 
     def g2_sr1_he_ap(self, z):
         return 10.504-(0.015*z)
+
+class S1PatternLikelihood_HE(Lichen):
+    """
+    This cut is meant to cut Gamma-X events and to help the rejection of multiple scatter evens. Moreover it is sensitive
+    also othe anomalies: unexpected S1 pattern, S1 and S2 not corresponding to the same interaction, ...
+    Note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:giovo:s1patternlikelihood_he
+    Contact: gvolta@physik.uzh.ch
+    """
+    version = 0.1
+    popt_z_1 =  [2.38811218e+02, 2.55991432e-05, 1.89468970e-01] #exp
+    popt_z_2 =  [1.05256551e+02, 7.72450878e-02] #poly1
+    popt_S1_1 = [1.49406369e+01,  2.62994597e+01, -1.01825116e+00,  1.27941177e-02] #cutline_S1_1
+    popt_S1_2 = [2.18914476e+02, 1.19392164e+02, 5.32460349e-05] #cutline_S1_2
+    S1_thr = 600
+    # Function for cut definition in z
+    def cutline_z_1(self, x):
+        return self.popt_z_1[0] + self.popt_z_1[1]*np.exp(-self.popt_z_1[2]*x)
+    # Function for cut definition in z
+    def cutline_z_2(self, x):
+        return self.popt_z_2[0] + self.popt_z_2[1]*x
+    # Function for cut definition below 600 PE
+    def cutline_S1_1(self, x):
+        return self.popt_S1_1[0] + self.popt_S1_1[1]*pow(x, 0.5) + self.popt_S1_1[2]*x + self.popt_S1_1[3]*pow(x, 1.5)
+    # Function for cut definition above 600 PE
+    def cutline_S1_2(self, x):
+        return self.popt_S1_2[0] + self.popt_S1_2[1]*np.arctan(self.popt_S1_2[2]*x)
+
+    def _process(self, df):
+        S1PL = df['s1_pattern_fit_bottom_hax']
+        z = df['z_3d_nn_tf']
+        S1 = df['s1']
+
+        cut_z_1   = (df['s1_pattern_fit_bottom_hax'] < self.cutline_z_1(df['z_3d_nn_tf']))
+        cut_z_2   = (df['s1_pattern_fit_bottom_hax'] > self.cutline_z_2(df['z_3d_nn_tf']))
+        cut_S1_1 = ((df['s1_pattern_fit_bottom_hax'] < self.cutline_S1_1(df['s1']))&(df['s1']<self.S1_thr))
+        cut_S1_2 = ((df['s1_pattern_fit_bottom_hax'] < self.cutline_S1_2(df['s1']))&(df['s1']>=self.S1_thr))
+        cut = (cut_z_1&cut_z_2)&(cut_S1_1|cut_S1_2)
+        df.loc[:, self.name()] = cut
+        return df    

--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -392,10 +392,10 @@ class S1PatternLikelihood_HE_2(Lichen):
     Contact: gvolta@physik.uzh.ch
     """
     
-    with open('/dali/lgrandi/giovo/XENON1T/S1pl_cutline/cut_line/interpolator_s1.pkl', 'rb') as f:
+    with open('/dali/lgrandi/giovo/XENON1T/S1pl_cutline/interpolator_s1.pkl', 'rb') as f:
         spl_S1_sr = pickle.load(f)
 
-    with open('/dali/lgrandi/giovo/XENON1T/S1pl_cutline/cut_line/interpolator_z.pkl', 'rb') as f:
+    with open('/dali/lgrandi/giovo/XENON1T/S1pl_cutline/interpolator_z.pkl', 'rb') as f:
         spl_z_sr = pickle.load(f)
     
     def first_line(self, x):

--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -403,7 +403,7 @@ class S1PatternLikelihood_HE_2(Lichen):
     def second_line(self):
         return 55.
     def z_high_fr(self, x):
-        retunr 2.36985250e+02 + 1.80524357e-03 *np.exp(-1.19723275e-01*x)
+        return 2.36985250e+02 + 1.80524357e-03 *np.exp(-1.19723275e-01*x)
     def z_low_fr(self, x):
         return 1.03477720e+02 + 3.53078631e-02 * x
     def S1_low_fr(self, x):
@@ -411,7 +411,7 @@ class S1PatternLikelihood_HE_2(Lichen):
     def S1_high_fr(self, x):
         return 2.35389331e+02 + 2.43058291e-03 * x
     def z_low_sr(self, x):
-        retunr 1.10549131e+02 + 3.64364369e-02 * x
+        return 1.10549131e+02 + 3.64364369e-02 * x
     
     def _process(self, df):
         S1PL = df['s1_pattern_fit_bottom_hax']

--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -400,7 +400,7 @@ class S1PatternLikelihood_HE_2(Lichen):
     
     def first_line(self, x):
         return x*(-3.16e-3) + 93.
-    def second_line(self):
+    def second_line(self, x):
         return 55.
     def z_high_fr(self, x):
         return 2.36985250e+02 + 1.80524357e-03 *np.exp(-1.19723275e-01*x)

--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -399,7 +399,7 @@ class S1PatternLikelihood_HE_2(Lichen):
         spl_z_sr = pickle.load(f)
     
     def first_line(self, x):
-        return x*(-3.16e(-3)) + 93.
+        return x*(-3.16e-3) + 93.
     def second_line(self):
         return 55.
     def z_high_fr(self, x):

--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -422,7 +422,7 @@ class S1PatternLikelihood_HE_2(Lichen):
         ### First region  ###
         first_line_down = (S1<=1.2e4)&(-z<self.first_line(z))
         second_line_down = (S1>1.2e4)&(-z<self.second_line(z))
-        cut_region_fr = first_line_down|second_line_down
+        cl_region_fr = first_line_down|second_line_down
         cl_z_high_fr = S1PL < self.z_high_fr(z)
         cl_z_low_fr = S1PL > self.z_low_fr(z)
         cl_S1_low_fr = (S1PL < self.S1_low_fr(S1))&(S1 < S1_thr)

--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -344,7 +344,7 @@ class S2Width_HE(Lichen):
     def g2_sr1_he_ap(self, z):
         return 10.504-(0.015*z)
 
-class S1PatternLikelihood_HE(Lichen):
+class S1PatternLikelihood_HE_hard(Lichen):
     """
     This cut is meant to cut Gamma-X events and to help the rejection of multiple scatter evens. Moreover it is sensitive
     also othe anomalies: unexpected S1 pattern, S1 and S2 not corresponding to the same interaction, ...
@@ -383,7 +383,7 @@ class S1PatternLikelihood_HE(Lichen):
         df.loc[:, self.name()] = cut
         return df
     
-class S1PatternLikelihood_HE_2(Lichen):
+class S1PatternLikelihood_HE_light(Lichen):
     """
     It has been observed that the S1 Pattern Likelihood cut for high energy rejects stimatic almost all events below ~ 80 cm. 
     This behaviour is not in agreement with the acceptance and rejection power defined in the previous analysis.
@@ -420,8 +420,8 @@ class S1PatternLikelihood_HE_2(Lichen):
         S1_thr = 772
         
         ### First region  ###
-        first_line_down = (S1<=1.2e4)&(-z<self.first_line(z))
-        second_line_down = (S1>1.2e4)&(-z<self.second_line(z))
+        first_line_down = (S1<=1.2e4)&(-z<self.first_line(S1))
+        second_line_down = (S1>1.2e4)&(-z<self.second_line(S1))
         cl_region_fr = first_line_down|second_line_down
         cl_z_high_fr = S1PL < self.z_high_fr(z)
         cl_z_low_fr = S1PL > self.z_low_fr(z)
@@ -431,8 +431,8 @@ class S1PatternLikelihood_HE_2(Lichen):
         cl_fr = cl_region_fr&(cl_z_high_fr&cl_z_low_fr)&(cl_S1_low_fr|cl_S1_high_fr)
         
         ### Second region  ###
-        first_line_up = (S1<=1.2e4)&(-z>self.first_line(z))
-        second_line_up = (S1>1.2e4)&(-z>self.second_line(z))
+        first_line_up = (S1<=1.2e4)&(-z>self.first_line(S1))
+        second_line_up = (S1>1.2e4)&(-z>self.second_line(S1))
         cl_region_sr = first_line_up|second_line_up
         cl_z_high_sr = S1PL < self.spl_z_sr(z)
         cl_z_low_sr = S1PL > self.z_low_sr(z)


### PR DESCRIPTION
# S1 pattern likelihood cut for HE

The main motivation for developing the extended version of S1 Pattern Likelihood cut is that at higher energies it can contribute to the multiple scatters rejections, where it expected that the Compton scattering dominates. The idea behind the multiple scatter rejection is that for these events the light pattern on the PMTs should be more distorted, due to the almost simultaneous multiple interactions, compare to single scatter events. The cut is also sensitive to other anomalous events: the dominant type of this event is known as the gamma-X event.
The method used is based on Log Likelihood calculation. A model of PMT pattern is obtained from simulation, hence, the Poisson Log Likelihood Ratio (λ) is computed for each event to be tested with respect to the model.
The cut has been developed through λ obtain only with the bottom PMT array and it has been optimised up to the RoI of neutrinoless double beta decay analysis. The data quality criteria has been defined in two parameter spaces using background data: (z; S1 pattern fit bottom hax) and (S1; S1 pattern fit bottom hax).
Finally, the acceptance and rejection power has been investigated thought the "photoelectric peak" events of the same background sample.