### PR TITLE
Update postsr1.py

### DIFF
--- a/lax/lichens/postsr1.py
+++ b/lax/lichens/postsr1.py
@@ -40,7 +40,7 @@ class ERband_HE(StringLichen):
  
     It returns the df after the ERband_HE cut, including a new variable called 'ces_ERband_HE'.
     The ERband definition uses data between 50—3020 keV with a precut z>-50.
-    Below 50 keV events will pass the cut. From 2 MeV to infinity (excluding the the blind region) the ERband is defined as the  average 1st and 99th percentile between 2-2.4 MeV. In the bling region the ER band is the average of the band defined between 1.190-1.220 MeV.  
+    Below 50 keV events will pass the cut. From 2 MeV to infinity (including the blinded region) the ERband is defined as the  average 1st and 99th percentile between 2-2.4 MeV.   
     The text file with the cut (ces value, Q50, Q99, Q1) can be found in /dali/lgrandi/manenti/cuts/ERband_HE/
     and in ../data/. 
     
@@ -54,7 +54,7 @@ class ERband_HE(StringLichen):
     def _process(self, df):
         
         #load mean, sigma values
-        ERband = np.genfromtxt('/dali/lgrandi/manenti/cuts/ERband_HE/ERband_Q50_Q99_Q1_50toInf_gapAs1.2MeV.txt',skip_header=1)
+        ERband = np.genfromtxt('/dali/lgrandi/manenti/cuts/ERband_HE/ERband_Q50_Q99_Q1_50toInf_gapAs2to2.4MeV.txt',skip_header=1)
         Q99 = ERband[:,2]
         Q1 = ERband[:,3]
         


### PR DESCRIPTION
As decided together with Andrii and Chiara, now the cut uses the following text file: 
/dali/lgrandi/manenti/cuts/ERband_HE/ERband_Q50_Q99_Q1_50toInf_gapAs2to2.4MeV.txt
where the extrapolation in the blinded region is the same as in the control outside, that means flat above 2 MeV.